### PR TITLE
update attribute handling and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rjvm"
 version = "0.3.0"
 dependencies = [
  "bitflags",
+ "thiserror",
 ]
+
+[[package]]
+name = "syn"
+version = "2.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["jvm", "java"]
 
 [dependencies]
 bitflags = "2.5.0"
+thiserror = "1.0.61"
 
 [features]
 default = ["decoder"]

--- a/examples/decoding.rs
+++ b/examples/decoding.rs
@@ -1,12 +1,16 @@
+use rjvm::bytecode::attributes::Container;
 use rjvm::bytecode::pool::ConstantPool;
 use rjvm::bytecode::reader::containers::read_classfile;
 use rjvm::bytecode::reader::BufferedReader;
 
 fn main() {
     let input = include_bytes!("./testdata/org/example/Simple.class");
+
+    let container = Container::new();
+
     let mut buffer = BufferedReader::new(input);
     let mut constant_pool = ConstantPool::new();
-    let cf = read_classfile(&mut buffer, &mut constant_pool).unwrap();
+    let cf = read_classfile(&mut buffer, &mut constant_pool, &container).unwrap();
 
     cf.methods.iter().for_each(|method| {
         dbg!(&method.descriptor);

--- a/examples/instructions.rs
+++ b/examples/instructions.rs
@@ -1,37 +1,56 @@
-use rjvm::bytecode::attributes::Attribute;
+use rjvm::bytecode::attributes::{CodeInfo, Container};
 use rjvm::bytecode::pool::ConstantPool;
+use rjvm::bytecode::reader::attributes::{
+    CodeAttributeFactory, ConstantValueAttributeFactory, InnerClassesAttributeFactory,
+    LineNumberTableAttributeFactory, LocalVariableTableAttributeFactory,
+    MethodParametersAttributeFactory, NestMembersAttributeFactory,
+    RuntimeInvisibleAnnotationsAttributeFactory, SourceFileAttributeFactory,
+};
 use rjvm::bytecode::reader::containers::read_classfile;
 use rjvm::bytecode::reader::BufferedReader;
 use rjvm::decoder::instructions::parse_instruction;
 
 fn main() {
     let input = include_bytes!("./testdata/org/example/Simple.class");
+
+    // -----------------------------------------------------------------------------
+    //  - Initialize a container with all available attributes -
+    // -----------------------------------------------------------------------------
+    let mut container = Container::new();
+    container.register("ConstantValue", ConstantValueAttributeFactory);
+    container.register("Code", CodeAttributeFactory);
+    container.register("LineNumberTable", LineNumberTableAttributeFactory);
+    container.register(
+        "RuntimeInvisibleAnnotations",
+        RuntimeInvisibleAnnotationsAttributeFactory,
+    );
+    container.register("SourceFile", SourceFileAttributeFactory);
+    container.register("NestMembers", NestMembersAttributeFactory);
+    container.register("InnerClasses", InnerClassesAttributeFactory);
+    container.register("LocalVariableTable", LocalVariableTableAttributeFactory);
+    container.register("MethodParameters", MethodParametersAttributeFactory);
+
     let mut buffer = BufferedReader::new(input);
     let mut constant_pool = ConstantPool::new();
-    let cf = read_classfile(&mut buffer, &mut constant_pool).unwrap();
+    let cf = read_classfile(&mut buffer, &mut constant_pool, &container).unwrap();
+
+    println!("cp size: {}", cf.constant_pool.size());
 
     println!("Class: {}", constant_pool.text_of(cf.this_class).unwrap());
     // print all methods and their instructions
     cf.methods.iter().for_each(|method| {
-        let attr = method
-            .attributes
-            .iter()
-            .find(|attr| matches!(attr, Attribute::Code(_)));
-        println!("Name: {}()", method.name);
-
-        let code = if let Attribute::Code(code) = attr.unwrap() {
-            code
-        } else {
-            panic!("Code attribute not found");
-        };
+        let attr_code = method.attributes.get("Code");
 
         // create a new buffer that contains just the code and nothing else...
-        let mut code_reader = BufferedReader::new(&code.code);
-        while !code_reader.has_remaining_data() {
-            let opcode = code_reader.take::<u8>().unwrap();
-            let instr =
-                parse_instruction(opcode, &mut code_reader).expect("instruction should be parsed");
-            println!("  0x{opcode:02x}: {}", instr);
+        if let Some(attr) = attr_code {
+            let attr = attr.as_any_ref().downcast_ref::<CodeInfo>().unwrap();
+            let mut code_reader = BufferedReader::new(&attr.code);
+            while !code_reader.has_remaining_data() {
+                let opcode = code_reader.take::<u8>().unwrap();
+                let instr = parse_instruction(opcode, &mut code_reader)
+                    .expect("instruction should be parsed");
+                println!("  0x{opcode:02x}: {}", instr);
+            }
         }
         println!();
     });

--- a/examples/printelements.rs
+++ b/examples/printelements.rs
@@ -47,8 +47,7 @@ fn main() {
             let attr_params: Vec<String> = method
                 .attributes
                 .get("MethodParameters")
-                .map(|attr| attr.as_any_ref().downcast_ref::<MethodParametersInfo>())
-                .flatten()
+                .and_then(|attr| attr.as_any_ref().downcast_ref::<MethodParametersInfo>())
                 .map(|params| {
                     params
                         .parameters
@@ -56,7 +55,7 @@ fn main() {
                         .map(|param| cp.text_of(param.name_index).unwrap())
                         .collect()
                 })
-                .unwrap_or(vec![]);
+                .unwrap_or_default();
 
             let desc_params = method
                 .descriptor

--- a/examples/printelements.rs
+++ b/examples/printelements.rs
@@ -1,12 +1,38 @@
+use rjvm::bytecode::attributes::{
+    element_value_string, Container, MethodParametersInfo, RuntimeInvisibleAnnotationsInfo,
+};
 use rjvm::bytecode::pool::ConstantPool;
+use rjvm::bytecode::reader::attributes::{
+    CodeAttributeFactory, ConstantValueAttributeFactory, InnerClassesAttributeFactory,
+    LineNumberTableAttributeFactory, LocalVariableTableAttributeFactory,
+    MethodParametersAttributeFactory, NestMembersAttributeFactory,
+    RuntimeInvisibleAnnotationsAttributeFactory, SourceFileAttributeFactory,
+};
 use rjvm::bytecode::reader::containers::read_classfile;
 use rjvm::bytecode::reader::BufferedReader;
+use rjvm::bytecode::{Descriptor, DescriptorKind};
+use rjvm::{Annotation, Method, Parameter, TypeRef};
 
 fn main() {
     let input = include_bytes!("./testdata/org/example/Simple.class");
+
+    let mut container = Container::new();
+    container.register("ConstantValue", ConstantValueAttributeFactory);
+    container.register("Code", CodeAttributeFactory);
+    container.register("LineNumberTable", LineNumberTableAttributeFactory);
+    container.register(
+        "RuntimeInvisibleAnnotations",
+        RuntimeInvisibleAnnotationsAttributeFactory,
+    );
+    container.register("SourceFile", SourceFileAttributeFactory);
+    container.register("NestMembers", NestMembersAttributeFactory);
+    container.register("InnerClasses", InnerClassesAttributeFactory);
+    container.register("LocalVariableTable", LocalVariableTableAttributeFactory);
+    container.register("MethodParameters", MethodParametersAttributeFactory);
+
     let mut buffer = BufferedReader::new(input);
     let mut cp = ConstantPool::new();
-    let cf = read_classfile(&mut buffer, &mut cp).unwrap();
+    let cf = read_classfile(&mut buffer, &mut cp, &container).unwrap();
 
     println!("Class name: {}", cp.text_of(cf.this_class).unwrap());
 
@@ -14,32 +40,91 @@ fn main() {
         println!("Field {} - {}", field.name, field.descriptor);
     });
 
-    // cf.methods.iter().for_each(|method| {
-    //     let parameters: Vec<Descriptor> = method
-    //         .descriptor
-    //         .clone()
-    //         .into_iter()
-    //         .filter(|desc| desc.kind == DescriptorKind::Parameter)
-    //         .collect();
-    //     let return_ty: Descriptor = method
-    //         .descriptor
-    //         .clone()
-    //         .into_iter()
-    //         .find(|desc| desc.kind == DescriptorKind::Return)
-    //         .unwrap_or(Descriptor {
-    //             kind: DescriptorKind::Return,
-    //             ty: FieldType::Base(BaseType::Void),
-    //         });
-    //
-    //     println!(
-    //         "{} {}({})",
-    //         return_ty,
-    //         method.name,
-    //         parameters
-    //             .iter()
-    //             .map(|p| p.ty.to_string())
-    //             .collect::<Vec<String>>()
-    //             .join(", ")
-    //     );
-    // });
+    let methods = cf
+        .methods
+        .iter()
+        .map(|method| {
+            let attr_params: Vec<String> = method
+                .attributes
+                .get("MethodParameters")
+                .map(|attr| attr.as_any_ref().downcast_ref::<MethodParametersInfo>())
+                .flatten()
+                .map(|params| {
+                    params
+                        .parameters
+                        .iter()
+                        .map(|param| cp.text_of(param.name_index).unwrap())
+                        .collect()
+                })
+                .unwrap_or(vec![]);
+
+            let desc_params = method
+                .descriptor
+                .iter()
+                .filter(|desc| desc.kind == DescriptorKind::Parameter)
+                .collect::<Vec<&Descriptor>>();
+
+            let parameters = desc_params
+                .iter()
+                .enumerate()
+                .map(|(i, desc)| {
+                    let name: Option<String> = attr_params.get(i).cloned();
+                    let ty = desc.ty.to_string();
+                    Parameter {
+                        name,
+                        ty: TypeRef { name: ty },
+                        position: i,
+                    }
+                })
+                .collect();
+
+            let ty: Option<TypeRef> = method
+                .descriptor
+                .iter()
+                .find(|desc| desc.kind == DescriptorKind::Return)
+                .map(|desc| TypeRef {
+                    name: desc.ty.to_string(),
+                });
+
+            let mut annotations: Vec<Annotation> = vec![];
+            if let Some(attr) = method
+                .get_attribute::<RuntimeInvisibleAnnotationsInfo>("RuntimeInvisibleAnnotations")
+            {
+                let items: Vec<Annotation> = attr
+                    .annotations
+                    .iter()
+                    .map(|item| {
+                        let name = cp.text_of(item.type_index).unwrap();
+                        let fields = item.element_value_pairs.iter().map(|pair| {
+                            let key = cp.text_of(pair.element_name_index).unwrap();
+                            let value = match element_value_string(&pair.value, &cp) {
+                                Ok(value) => value,
+                                Err(_) => {
+                                    // TODO: handle error case
+                                    unreachable!()
+                                }
+                            };
+                            (key, value)
+                        });
+                        Annotation {
+                            name,
+                            field: fields.collect(),
+                        }
+                    })
+                    .collect();
+                annotations.extend(items);
+            }
+
+            rjvm::Method {
+                name: method.name.clone(),
+                annotations,
+                modifiers: vec![],
+                parameters,
+                body: None,
+                ty,
+            }
+        })
+        .collect::<Vec<Method>>();
+
+    dbg!(methods);
 }

--- a/src/bytecode/attributes.rs
+++ b/src/bytecode/attributes.rs
@@ -361,6 +361,34 @@ pub enum ElementValue {
     },
 }
 
+pub fn element_value_string(
+    value: &ElementValue,
+    pool: &ConstantPool,
+) -> Result<String, BytecodeError> {
+    match value {
+        ElementValue::ConstValueIndex(idx) => match pool.text_of(idx.clone()) {
+            Some(str) => Ok(str.to_string()),
+            None => Err(BytecodeError::ConstantPoolEntryNotFound),
+        },
+        ElementValue::EnumConstValue {
+            type_name_index: _,
+            const_name_index: _,
+        } => {
+            todo!()
+        }
+        ElementValue::ClassInfoIndex(idx) => match pool.text_of(idx.clone()) {
+            Some(str) => Ok(str.to_string()),
+            None => Err(BytecodeError::ConstantPoolEntryNotFound),
+        },
+        ElementValue::Annotation(_annotation) => {
+            todo!()
+        }
+        ElementValue::Array { values: _, .. } => {
+            todo!()
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParameterAnnotation {
     pub num_annotations: u16,

--- a/src/bytecode/attributes.rs
+++ b/src/bytecode/attributes.rs
@@ -47,8 +47,8 @@ impl Container {
         self.inner.insert(name, Box::new(factory));
     }
 
-    pub fn get_by_name(&self, name: &str) -> Option<&Box<dyn AttributeFactory>> {
-        self.inner.get(name)
+    pub fn get_by_name(&self, name: &str) -> Option<&dyn AttributeFactory> {
+        self.inner.get(name).map(|f| f.as_ref())
     }
 }
 
@@ -366,7 +366,7 @@ pub fn element_value_string(
     pool: &ConstantPool,
 ) -> Result<String, BytecodeError> {
     match value {
-        ElementValue::ConstValueIndex(idx) => match pool.text_of(idx.clone()) {
+        ElementValue::ConstValueIndex(idx) => match pool.text_of(*idx) {
             Some(str) => Ok(str.to_string()),
             None => Err(BytecodeError::ConstantPoolEntryNotFound),
         },
@@ -376,7 +376,7 @@ pub fn element_value_string(
         } => {
             todo!()
         }
-        ElementValue::ClassInfoIndex(idx) => match pool.text_of(idx.clone()) {
+        ElementValue::ClassInfoIndex(idx) => match pool.text_of(*idx) {
             Some(str) => Ok(str.to_string()),
             None => Err(BytecodeError::ConstantPoolEntryNotFound),
         },

--- a/src/bytecode/attributes.rs
+++ b/src/bytecode/attributes.rs
@@ -1,80 +1,260 @@
+use std::collections::HashMap;
+
+use super::pool::ConstantPool;
+use super::reader::BufferedReader;
+use super::BytecodeError;
 use crate::bytecode::flags::InnerClassAccessFlags;
 use crate::bytecode::pool::ConstantPoolIndex;
 
-#[derive(Debug)]
-pub enum Attribute {
-    ConstantValue(ConstantValueInfo),
-    Code(CodeInfo),
-    StackMapTable(StackMapTableInfo),
-    Exceptions(ExceptionsInfo),
-    InnerClasses(InnerClassesInfo),
-    EnclosingMethod(EnclosingMethodInfo),
-    Synthetic(SyntheticInfo),
-    Signature(SignatureInfo),
-    SourceFile(SourceFileInfo),
-    SourceDebugExtension(SourceDebugExtensionInfo),
-    LineNumberTable(LineNumberTableInfo),
-    LocalVariableTable(LocalVariableTableInfo),
-    LocalVariableTypeTable(LocalVariableTypeTableInfo),
-    Deprecated(DeprecatedInfo),
-    RuntimeVisibleAnnotations(RuntimeVisibleAnnotationsInfo),
-    RuntimeInvisibleAnnotations(RuntimeInvisibleAnnotationsInfo),
-    RuntimeVisibleParameterAnnotations(RuntimeVisibleParameterAnnotationsInfo),
-    RuntimeInvisibleParameterAnnotations(RuntimeInvisibleParameterAnnotationsInfo),
-    RuntimeVisibleTypeAnnotations(RuntimeVisibleTypeAnnotationsInfo),
-    RuntimeInvisibleTypeAnnotations(RuntimeInvisibleTypeAnnotationsInfo),
-    AnnotationDefault(AnnotationDefaultInfo),
-    BootstrapMethods(BootstrapMethodsInfo),
-    MethodParameters(MethodParametersInfo),
-    Module(ModuleInfo),
-    ModulePackages(ModulePackagesInfo),
-    ModuleMainClass(ModuleMainClassInfo),
-    NestHost(NestHostInfo),
-    NestMembers(NestMembersInfo),
-    Record(RecordInfo),
-    PermittedSubtypes(PermittedSubtypesInfo),
+pub trait Attribute {
+    /// Returns the name of the attribute.
+    ///
+    /// WARNING: This should only be used for debugging purposes because there is no guarantee that
+    /// no other `AttributeInfo` implementation will return the same name.
+    fn name(&self) -> &'static str {
+        "[unknown attribute]"
+    }
 }
 
-impl std::fmt::Display for Attribute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ConstantValue(_) => write!(f, "ConstantValue"),
-            Self::Code(_) => write!(f, "Code"),
-            Self::StackMapTable(_) => write!(f, "StackMapTable"),
-            Self::Exceptions(_) => write!(f, "Exceptions"),
-            Self::InnerClasses(_) => write!(f, "InnerClasses"),
-            Self::EnclosingMethod(_) => write!(f, "EnclosingMethod"),
-            Self::Synthetic(_) => write!(f, "Synthetic"),
-            Self::Signature(_) => write!(f, "Signature"),
-            Self::SourceFile(_) => write!(f, "SourceFile"),
-            Self::SourceDebugExtension(_) => write!(f, "SourceDebugExtension"),
-            Self::LineNumberTable(_) => write!(f, "LineNumberTable"),
-            Self::LocalVariableTable(_) => write!(f, "LocalVariableTable"),
-            Self::LocalVariableTypeTable(_) => write!(f, "LocalVariableTypeTable"),
-            Self::Deprecated(_) => write!(f, "Deprecated"),
-            Self::RuntimeVisibleAnnotations(_) => write!(f, "RuntimeVisibleAnnotations"),
-            Self::RuntimeInvisibleAnnotations(_) => write!(f, "RuntimeInvisibleAnnotations"),
-            Self::RuntimeVisibleParameterAnnotations(_) => {
-                write!(f, "RuntimeVisibleParameterAnnotations")
-            }
-            Self::RuntimeInvisibleParameterAnnotations(_) => {
-                write!(f, "RuntimeInvisibleParameterAnnotations")
-            }
-            Self::RuntimeVisibleTypeAnnotations(_) => write!(f, "RuntimeVisibleTypeAnnotations"),
-            Self::RuntimeInvisibleTypeAnnotations(_) => {
-                write!(f, "RuntimeInvisibleTypeAnnotations")
-            }
-            Self::AnnotationDefault(_) => write!(f, "AnnotationDefault"),
-            Self::BootstrapMethods(_) => write!(f, "BootstrapMethods"),
-            Self::MethodParameters(_) => write!(f, "MethodParameters"),
-            Self::Module(_) => write!(f, "Module"),
-            Self::ModulePackages(_) => write!(f, "ModulePackages"),
-            Self::ModuleMainClass(_) => write!(f, "ModuleMainClass"),
-            Self::NestHost(_) => write!(f, "NestHost"),
-            Self::NestMembers(_) => write!(f, "NestMembers"),
-            Self::Record(_) => write!(f, "Record"),
-            Self::PermittedSubtypes(_) => write!(f, "PermittedSubtypes"),
+pub trait AttributeFactory: std::fmt::Debug {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError>;
+}
+
+#[derive(Debug)]
+pub struct Container {
+    inner: HashMap<&'static str, Box<dyn AttributeFactory>>,
+}
+
+impl Default for Container {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Container {
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
         }
+    }
+
+    pub fn register(&mut self, name: &'static str, factory: impl AttributeFactory + 'static) {
+        self.inner.insert(name, Box::new(factory));
+    }
+
+    pub fn get_by_name(&self, name: &str) -> Option<&Box<dyn AttributeFactory>> {
+        self.inner.get(name)
+    }
+}
+
+impl Attribute for Box<dyn Attribute> {
+    fn name(&self) -> &'static str {
+        self.as_ref().name()
+    }
+}
+
+pub trait AnyAttribute: std::fmt::Debug {
+    fn as_any_ref(&self) -> &dyn std::any::Any;
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+    fn name_any(&self) -> &'static str;
+}
+
+impl<T: std::fmt::Debug + Attribute + 'static> AnyAttribute for T {
+    fn as_any_ref(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn name_any(&self) -> &'static str {
+        self.name()
+    }
+}
+
+impl Attribute for ConstantValueInfo {
+    fn name(&self) -> &'static str {
+        "ConstantValue"
+    }
+}
+
+impl Attribute for CodeInfo {
+    fn name(&self) -> &'static str {
+        "Code"
+    }
+}
+
+impl Attribute for StackMapTableInfo {
+    fn name(&self) -> &'static str {
+        "StackMapTable"
+    }
+}
+
+impl Attribute for ExceptionsInfo {
+    fn name(&self) -> &'static str {
+        "Exceptions"
+    }
+}
+
+impl Attribute for InnerClassesInfo {
+    fn name(&self) -> &'static str {
+        "InnerClasses"
+    }
+}
+
+impl Attribute for EnclosingMethodInfo {
+    fn name(&self) -> &'static str {
+        "EnclosingMethod"
+    }
+}
+
+impl Attribute for SyntheticInfo {
+    fn name(&self) -> &'static str {
+        "Synthetic"
+    }
+}
+
+impl Attribute for SignatureInfo {
+    fn name(&self) -> &'static str {
+        "Signature"
+    }
+}
+
+impl Attribute for SourceFileInfo {
+    fn name(&self) -> &'static str {
+        "SourceFile"
+    }
+}
+
+impl Attribute for SourceDebugExtensionInfo {
+    fn name(&self) -> &'static str {
+        "SourceDebugExtension"
+    }
+}
+
+impl Attribute for LineNumberTableInfo {
+    fn name(&self) -> &'static str {
+        "LineNumberTable"
+    }
+}
+
+impl Attribute for LocalVariableTableInfo {
+    fn name(&self) -> &'static str {
+        "LocalVariableTable"
+    }
+}
+
+impl Attribute for LocalVariableTypeTableInfo {
+    fn name(&self) -> &'static str {
+        "LocalVariableTypeTable"
+    }
+}
+
+impl Attribute for DeprecatedInfo {
+    fn name(&self) -> &'static str {
+        "Deprecated"
+    }
+}
+
+impl Attribute for RuntimeVisibleAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeVisibleAnnotations"
+    }
+}
+
+impl Attribute for RuntimeInvisibleAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeInvisibleAnnotations"
+    }
+}
+
+impl Attribute for RuntimeVisibleParameterAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeVisibleParameterAnnotations"
+    }
+}
+
+impl Attribute for RuntimeInvisibleParameterAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeInvisibleParameterAnnotations"
+    }
+}
+
+impl Attribute for RuntimeVisibleTypeAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeVisibleTypeAnnotations"
+    }
+}
+
+impl Attribute for RuntimeInvisibleTypeAnnotationsInfo {
+    fn name(&self) -> &'static str {
+        "RuntimeInvisibleTypeAnnotations"
+    }
+}
+
+impl Attribute for AnnotationDefaultInfo {
+    fn name(&self) -> &'static str {
+        "AnnotationDefault"
+    }
+}
+
+impl Attribute for BootstrapMethodsInfo {
+    fn name(&self) -> &'static str {
+        "BootstrapMethods"
+    }
+}
+
+impl Attribute for MethodParametersInfo {
+    fn name(&self) -> &'static str {
+        "MethodParameters"
+    }
+}
+
+impl Attribute for ModuleInfo {
+    fn name(&self) -> &'static str {
+        "Module"
+    }
+}
+
+impl Attribute for ModulePackagesInfo {
+    fn name(&self) -> &'static str {
+        "ModulePackages"
+    }
+}
+
+impl Attribute for ModuleMainClassInfo {
+    fn name(&self) -> &'static str {
+        "ModuleMainClass"
+    }
+}
+
+impl Attribute for NestHostInfo {
+    fn name(&self) -> &'static str {
+        "NestHost"
+    }
+}
+
+impl Attribute for NestMembersInfo {
+    fn name(&self) -> &'static str {
+        "NestMembers"
+    }
+}
+
+impl Attribute for RecordInfo {
+    fn name(&self) -> &'static str {
+        "Record"
+    }
+}
+
+impl Attribute for PermittedSubtypesInfo {
+    fn name(&self) -> &'static str {
+        "PermittedSubtypes"
     }
 }
 
@@ -312,7 +492,7 @@ pub struct RecordComponent {
     pub name_index: ConstantPoolIndex,
     pub descriptor_index: ConstantPoolIndex,
     pub attributes_count: u16,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -369,7 +549,7 @@ pub struct CodeInfo {
     pub exception_table_length: u16,
     pub exception_table: Vec<ExceptionTableEntry>,
     pub attributes_count: u16,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug)]
@@ -586,7 +766,7 @@ pub struct RecordInfo {
     pub attribute_name_index: ConstantPoolIndex,
     pub attribute_length: u32,
     pub component_count: u16,
-    pub components: Vec<Attribute>,
+    pub components: Vec<Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug)]

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -64,6 +64,15 @@ pub struct Method {
     pub attributes: HashMap<&'static str, Box<dyn AnyAttribute>>,
 }
 
+impl Method {
+    pub fn get_attribute<T: AnyAttribute + 'static>(&self, name: &str) -> Option<&T> {
+        self.attributes
+            .get(name)
+            .map(|attr| attr.as_any_ref().downcast_ref::<T>())
+            .flatten()
+    }
+}
+
 #[derive(Debug)]
 pub struct Interface {
     pub name_index: ConstantPoolIndex,

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -68,8 +68,7 @@ impl Method {
     pub fn get_attribute<T: AnyAttribute + 'static>(&self, name: &str) -> Option<&T> {
         self.attributes
             .get(name)
-            .map(|attr| attr.as_any_ref().downcast_ref::<T>())
-            .flatten()
+            .and_then(|attr| attr.as_any_ref().downcast_ref::<T>())
     }
 }
 

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -1,4 +1,6 @@
-use crate::bytecode::attributes::Attribute;
+use std::collections::HashMap;
+
+use self::attributes::AnyAttribute;
 use crate::bytecode::flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use crate::bytecode::pool::{ConstantPool, ConstantPoolIndex};
 
@@ -12,7 +14,7 @@ pub mod reader;
 pub enum BytecodeError {
     ConstantPoolEntryAlreadyExists,
     ConstantPoolEntryNotFound,
-    UnsupportedAttributeName,
+    UnsupportedAttributeName(String),
     InvalidClassFile,
     UnexpectedEndOfData,
     InvalidData,
@@ -43,7 +45,7 @@ pub struct ClassFile {
     pub methods_count: u16,
     pub methods: Vec<Method>,
     pub attributes_count: u16,
-    pub attributes: Vec<Attribute>,
+    pub attributes: HashMap<&'static str, Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug)]
@@ -51,7 +53,7 @@ pub struct Field {
     pub name: String,
     pub descriptor: Descriptor,
     pub access_flags: FieldAccessFlags,
-    pub attributes: Vec<Attribute>,
+    pub attributes: HashMap<&'static str, Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug)]
@@ -59,7 +61,7 @@ pub struct Method {
     pub access_flags: MethodAccessFlags,
     pub name: String,
     pub descriptor: Vec<Descriptor>,
-    pub attributes: Vec<Attribute>,
+    pub attributes: HashMap<&'static str, Box<dyn AnyAttribute>>,
 }
 
 #[derive(Debug)]

--- a/src/bytecode/reader/attributes.rs
+++ b/src/bytecode/reader/attributes.rs
@@ -1,17 +1,18 @@
 use crate::bytecode::attributes::{
-    Annotation, AnnotationDefaultInfo, Attribute, BootstrapMethod, BootstrapMethodsInfo, CodeInfo,
-    ConstantValueInfo, DeprecatedInfo, ElementValue, ElementValuePair, EnclosingMethodInfo,
-    ExceptionTableEntry, ExceptionsInfo, Exports, InnerClass, InnerClassesInfo,
-    LineNumberTableEntry, LineNumberTableInfo, LocalVarTargetTableEntry, LocalVariableTableEntry,
-    LocalVariableTableInfo, LocalVariableTypeTableEntry, LocalVariableTypeTableInfo,
-    MethodParameter, MethodParametersInfo, ModuleInfo, ModuleMainClassInfo, ModulePackagesInfo,
-    NestHostInfo, NestMembersInfo, Opens, ParameterAnnotation, PermittedSubtypesInfo, Provides,
-    RecordInfo, Requires, RuntimeInvisibleAnnotationsInfo,
-    RuntimeInvisibleParameterAnnotationsInfo, RuntimeInvisibleTypeAnnotationsInfo,
-    RuntimeVisibleAnnotationsInfo, RuntimeVisibleParameterAnnotationsInfo,
-    RuntimeVisibleTypeAnnotationsInfo, SignatureInfo, SourceDebugExtensionInfo, SourceFileInfo,
-    StackMapFrame, StackMapTableInfo, SyntheticInfo, TypeAnnotation, TypeAnnotationTargetInfo,
-    TypeAnnotationTargetInfoType, TypePath, TypePathEntry, VerificationTypeInfo,
+    Annotation, AnnotationDefaultInfo, AnyAttribute, AttributeFactory, BootstrapMethod,
+    BootstrapMethodsInfo, CodeInfo, ConstantValueInfo, Container, DeprecatedInfo, ElementValue,
+    ElementValuePair, EnclosingMethodInfo, ExceptionTableEntry, ExceptionsInfo, Exports,
+    InnerClass, InnerClassesInfo, LineNumberTableEntry, LineNumberTableInfo,
+    LocalVarTargetTableEntry, LocalVariableTableEntry, LocalVariableTableInfo,
+    LocalVariableTypeTableEntry, LocalVariableTypeTableInfo, MethodParameter, MethodParametersInfo,
+    ModuleInfo, ModuleMainClassInfo, ModulePackagesInfo, NestHostInfo, NestMembersInfo, Opens,
+    ParameterAnnotation, PermittedSubtypesInfo, Provides, RecordInfo, Requires,
+    RuntimeInvisibleAnnotationsInfo, RuntimeInvisibleParameterAnnotationsInfo,
+    RuntimeInvisibleTypeAnnotationsInfo, RuntimeVisibleAnnotationsInfo,
+    RuntimeVisibleParameterAnnotationsInfo, RuntimeVisibleTypeAnnotationsInfo, SignatureInfo,
+    SourceDebugExtensionInfo, SourceFileInfo, StackMapFrame, StackMapTableInfo, SyntheticInfo,
+    TypeAnnotation, TypeAnnotationTargetInfo, TypeAnnotationTargetInfoType, TypePath,
+    TypePathEntry, VerificationTypeInfo,
 };
 use crate::bytecode::flags::InnerClassAccessFlags;
 use crate::bytecode::pool::{ConstantPool, ConstantPoolIndex};
@@ -21,149 +22,30 @@ use crate::bytecode::BytecodeError;
 pub fn read_attribute(
     reader: &mut BufferedReader,
     cp: &mut ConstantPool,
-) -> Result<Attribute, BytecodeError> {
+    container: &Container,
+) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
     let attribute_name_index = reader.peek_bytes::<u16>()?;
-    let Some(attribute_name) = cp.text_of(attribute_name_index.into()) else {
+    let Some(name) = cp.text_of(attribute_name_index.into()) else {
         return Err(BytecodeError::InvalidData);
     };
 
-    let attribute = match attribute_name.as_str() {
-        "ConstantValue" => {
-            let result = read_constantvalue_info(reader, cp)?;
-            Attribute::ConstantValue(result)
-        }
-        "Code" => {
-            let result = read_code_info(reader, cp)?;
-            Attribute::Code(result)
-        }
-        "StackMapTable" => {
-            let result = read_stackmaptable_info(reader, cp)?;
-            Attribute::StackMapTable(result)
-        }
-        "Exceptions" => {
-            let result = read_exceptions_info(reader, cp)?;
-            Attribute::Exceptions(result)
-        }
-        "InnerClasses" => {
-            let result = read_innerclasses_info(reader, cp)?;
-            Attribute::InnerClasses(result)
-        }
-        "EnclosingMethod" => {
-            let result = read_enclosingmethod_info(reader, cp)?;
-            Attribute::EnclosingMethod(result)
-        }
-        "Synthetic" => {
-            let result = read_synthetic_info(reader, cp)?;
-            Attribute::Synthetic(result)
-        }
-        "Signature" => {
-            let result = read_signature_info(reader, cp)?;
-            Attribute::Signature(result)
-        }
-        "SourceFile" => {
-            let result = read_sourcefile_info(reader, cp)?;
-            Attribute::SourceFile(result)
-        }
-        "SourceDebugExtension" => {
-            let result = read_sourcedebugextension_info(reader, cp)?;
-            Attribute::SourceDebugExtension(result)
-        }
-        "LineNumberTable" => {
-            let result = read_linenumbertable_info(reader, cp)?;
-            Attribute::LineNumberTable(result)
-        }
-        "LocalVariableTable" => {
-            let result = read_localvariabletable_info(reader, cp)?;
-            Attribute::LocalVariableTable(result)
-        }
-        "LocalVariableTypeTable" => {
-            let result = read_localvariabletypetable_info(reader, cp)?;
-            Attribute::LocalVariableTypeTable(result)
-        }
-        "Deprecated" => {
-            let result = read_deprecated_info(reader, cp)?;
-            Attribute::Deprecated(result)
-        }
-        "RuntimeVisibleAnnotations" => {
-            let result = read_runtimevisibleannotations_info(reader, cp)?;
-            Attribute::RuntimeVisibleAnnotations(result)
-        }
-        "RuntimeInvisibleAnnotations" => {
-            let result = read_runtimeinvisibleannotations_info(reader, cp)?;
-            Attribute::RuntimeInvisibleAnnotations(result)
-        }
-        "RuntimeVisibleParameterAnnotations" => {
-            let result = read_runtimevisibleparameterannotations_info(reader, cp)?;
-            Attribute::RuntimeVisibleParameterAnnotations(result)
-        }
-        "RuntimeInvisibleParameterAnnotations" => {
-            let result = read_runtimeinvisibleparameterannotations_info(reader, cp)?;
-            Attribute::RuntimeInvisibleParameterAnnotations(result)
-        }
-        "RuntimeVisibleTypeAnnotations" => {
-            let result = read_runtimevisibletypeannotations_info(reader, cp)?;
-            Attribute::RuntimeVisibleTypeAnnotations(result)
-        }
-        "RuntimeInvisibleTypeAnnotations" => {
-            let result = read_runtimeinvisibletypeannotations_info(reader, cp)?;
-            Attribute::RuntimeInvisibleTypeAnnotations(result)
-        }
-        "AnnotationDefault" => {
-            let result = read_annotationdefault_info(reader, cp)?;
-            Attribute::AnnotationDefault(result)
-        }
-        "BootstrapMethods" => {
-            let result = read_bootstrapmethods_info(reader, cp)?;
-            Attribute::BootstrapMethods(result)
-        }
-        "MethodParameters" => {
-            let result = read_methodparameters_info(reader, cp)?;
-            Attribute::MethodParameters(result)
-        }
-        "Module" => {
-            let result = read_module_info(reader, cp)?;
-            Attribute::Module(result)
-        }
-        "ModulePackages" => {
-            let result = read_modulepackages_info(reader, cp)?;
-            Attribute::ModulePackages(result)
-        }
-        "ModuleMainClass" => {
-            let result = read_modulemainclass_info(reader, cp)?;
-            Attribute::ModuleMainClass(result)
-        }
-        "NestHost" => {
-            let result = read_nesthost_info(reader, cp)?;
-            Attribute::NestHost(result)
-        }
-        "NestMembers" => {
-            let result = read_nestmembers_info(reader, cp)?;
-            Attribute::NestMembers(result)
-        }
-        "Record" => {
-            let result = read_record_info(reader, cp)?;
-            Attribute::Record(result)
-        }
-        "PermittedSubtypes" => {
-            let result = read_permittedsubtypes_info(reader, cp)?;
-            Attribute::PermittedSubtypes(result)
-        }
-        _ => return Err(BytecodeError::UnsupportedAttributeName),
+    let Some(attr) = container.get_by_name(&name) else {
+        return Err(BytecodeError::UnsupportedAttributeName(name));
     };
 
-    Ok(attribute)
+    attr.make(reader, cp, container)
 }
 
 fn read_annotation(
     reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
+    pool: &mut ConstantPool,
 ) -> Result<Annotation, BytecodeError> {
     let type_index = reader.take::<u16>()?;
     let num_element_value_pairs = reader.take::<u16>()?;
     let mut element_value_pairs = Vec::with_capacity(num_element_value_pairs as usize);
     for _ in 0..num_element_value_pairs {
         let element_name_index = reader.take::<u16>()?;
-        let element_value = read_elementvalue(reader, cp)?;
+        let element_value = read_elementvalue(reader, pool)?;
         element_value_pairs.push(ElementValuePair {
             element_name_index: ConstantPoolIndex::new(element_name_index),
             value: element_value,
@@ -177,37 +59,33 @@ fn read_annotation(
     })
 }
 
-fn read_annotationdefault_info(
+fn read_typeannotation(
     reader: &mut BufferedReader,
     cp: &mut ConstantPool,
-) -> Result<AnnotationDefaultInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let default_value = read_elementvalue(reader, cp)?;
-
-    Ok(AnnotationDefaultInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        default_value,
-    })
-}
-
-fn read_typepath(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<TypePath, BytecodeError> {
-    let path_length = reader.take::<u8>()?;
-    let mut path = Vec::with_capacity(path_length as usize);
-    for _ in 0..path_length {
-        let type_path_kind = reader.take::<u8>()?;
-        let type_argument_index = reader.take::<u8>()?;
-        path.push(TypePathEntry {
-            type_path_kind,
-            type_argument_index: ConstantPoolIndex::new(type_argument_index),
+) -> Result<TypeAnnotation, BytecodeError> {
+    let target_type = reader.take::<u8>()?;
+    let target_info = read_typeannotationtarget_info(reader, cp)?;
+    let target_path = read_typepath(reader, cp)?;
+    let type_index = reader.take::<u16>()?;
+    let num_element_value_pairs = reader.take::<u16>()?;
+    let mut element_value_pairs = Vec::with_capacity(num_element_value_pairs as usize);
+    for _ in 0..num_element_value_pairs {
+        let element_name_index = reader.take::<u16>()?;
+        let element_value = read_elementvalue(reader, cp)?;
+        element_value_pairs.push(ElementValuePair {
+            element_name_index: ConstantPoolIndex::new(element_name_index),
+            value: element_value,
         });
     }
 
-    Ok(TypePath { path_length, path })
+    Ok(TypeAnnotation {
+        target_type,
+        target_info,
+        target_path,
+        type_index: ConstantPoolIndex::new(type_index),
+        num_element_value_pairs,
+        element_value_pairs,
+    })
 }
 
 fn read_typeannotationtarget_info(
@@ -288,6 +166,1151 @@ fn read_typeannotationtarget_info(
     Ok(TypeAnnotationTargetInfo { target_info })
 }
 
+#[derive(Debug)]
+pub struct ConstantValueAttributeFactory;
+
+#[derive(Debug)]
+pub struct CodeAttributeFactory;
+
+#[derive(Debug)]
+pub struct LineNumberTableAttributeFactory;
+
+impl AttributeFactory for ConstantValueAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let constantvalue_index = reader.take::<u16>()?;
+
+        Ok(Box::new(ConstantValueInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            constantvalue_index: ConstantPoolIndex::new(constantvalue_index),
+        }))
+    }
+}
+
+impl AttributeFactory for CodeAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let max_stack = reader.take::<u16>()?;
+        let max_locals = reader.take::<u16>()?;
+        let code_length = reader.take::<u32>()?;
+        let code = reader.take_bytes(code_length as usize)?;
+        let exception_table_length = reader.take::<u16>()?;
+        let mut exception_table = Vec::with_capacity(exception_table_length as usize);
+        for _ in 0..exception_table_length {
+            let start_pc = reader.take::<u16>()?;
+            let end_pc = reader.take::<u16>()?;
+            let handler_pc = reader.take::<u16>()?;
+            let catch_type = reader.take::<u16>()?;
+            exception_table.push(ExceptionTableEntry {
+                start_pc,
+                end_pc,
+                handler_pc,
+                catch_type: ConstantPoolIndex::new(catch_type),
+            });
+        }
+        let attributes_count = reader.take::<u16>()?;
+        let mut attributes = Vec::with_capacity(attributes_count as usize);
+        for _ in 0..attributes_count {
+            let attribute = read_attribute(reader, pool, container)?;
+            attributes.push(attribute);
+        }
+
+        Ok(Box::new(CodeInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            max_stack,
+            max_locals,
+            code_length,
+            code: code.to_vec(),
+            exception_table_length,
+            exception_table,
+            attributes_count,
+            attributes,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct StackMapTableAttributeFactory;
+
+impl AttributeFactory for StackMapTableAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let number_of_entries = reader.take::<u16>()?;
+        let frame_type = reader.take::<u8>()?;
+        let mut entries = Vec::with_capacity(number_of_entries as usize);
+        for _ in 0..number_of_entries {
+            let entry = match frame_type {
+                0..=63 => StackMapFrame::SameFrame { frame_type },
+                64..=127 => {
+                    let verification_type = reader.take::<u8>()?;
+                    let verification_type = match verification_type {
+                        0 => VerificationTypeInfo::Top,
+                        1 => VerificationTypeInfo::Integer,
+                        2 => VerificationTypeInfo::Float,
+                        3 => VerificationTypeInfo::Double,
+                        4 => VerificationTypeInfo::Long,
+                        5 => VerificationTypeInfo::Null,
+                        6 => VerificationTypeInfo::UninitializedThis,
+                        7 => {
+                            let class = reader.take::<u16>()?;
+                            VerificationTypeInfo::Object {
+                                class: class.into(),
+                            }
+                        }
+                        8 => {
+                            let offset = reader.take::<u16>()?;
+                            VerificationTypeInfo::Uninitialized { offset }
+                        }
+                        _ => return Err(BytecodeError::UnsupportedVerificationType),
+                    };
+                    StackMapFrame::SameLocals1StackItemFrame {
+                        frame_type,
+                        stack: verification_type,
+                    }
+                }
+                247 => {
+                    let offset_delta = reader.take::<u16>()?;
+                    let verification_type = reader.take::<u8>()?;
+                    let verification_type = match verification_type {
+                        0 => VerificationTypeInfo::Top,
+                        1 => VerificationTypeInfo::Integer,
+                        2 => VerificationTypeInfo::Float,
+                        3 => VerificationTypeInfo::Double,
+                        4 => VerificationTypeInfo::Long,
+                        5 => VerificationTypeInfo::Null,
+                        6 => VerificationTypeInfo::UninitializedThis,
+                        7 => {
+                            let class = reader.take::<u16>()?;
+                            VerificationTypeInfo::Object {
+                                class: class.into(),
+                            }
+                        }
+                        8 => {
+                            let offset = reader.take::<u16>()?;
+                            VerificationTypeInfo::Uninitialized { offset }
+                        }
+                        _ => return Err(BytecodeError::UnsupportedVerificationType),
+                    };
+
+                    StackMapFrame::SameLocals1StackItemFrameExtended {
+                        frame_type,
+                        offset_delta,
+                        stack: verification_type,
+                    }
+                }
+                248..=250 => {
+                    let offset_delta = reader.take::<u16>()?;
+                    StackMapFrame::ChopFrame {
+                        frame_type,
+                        offset_delta,
+                    }
+                }
+                251 => {
+                    let offset_delta = reader.take::<u16>()?;
+                    StackMapFrame::SameFrameExtended {
+                        frame_type,
+                        offset_delta,
+                    }
+                }
+                252..=254 => {
+                    let offset_delta = reader.take::<u16>()?;
+                    let mut locals = Vec::with_capacity(frame_type as usize - 251);
+                    for _ in 0..frame_type - 251 {
+                        let verification_type = reader.take::<u8>()?;
+                        let verification_type = match verification_type {
+                            0 => VerificationTypeInfo::Top,
+                            1 => VerificationTypeInfo::Integer,
+                            2 => VerificationTypeInfo::Float,
+                            3 => VerificationTypeInfo::Double,
+                            4 => VerificationTypeInfo::Long,
+                            5 => VerificationTypeInfo::Null,
+                            6 => VerificationTypeInfo::UninitializedThis,
+                            7 => {
+                                let class = reader.take::<u16>()?;
+                                VerificationTypeInfo::Object {
+                                    class: class.into(),
+                                }
+                            }
+                            8 => {
+                                let offset = reader.take::<u16>()?;
+                                VerificationTypeInfo::Uninitialized { offset }
+                            }
+                            _ => return Err(BytecodeError::UnsupportedVerificationType),
+                        };
+                        locals.push(verification_type);
+                    }
+                    StackMapFrame::AppendFrame {
+                        frame_type,
+                        offset_delta,
+                        locals,
+                    }
+                }
+                255 => {
+                    let offset_delta = reader.take::<u16>()?;
+                    let number_of_locals = reader.take::<u16>()?;
+                    let mut locals = Vec::with_capacity(number_of_locals as usize);
+                    for _ in 0..number_of_locals {
+                        let verification_type = reader.take::<u8>()?;
+                        let verification_type = match verification_type {
+                            0 => VerificationTypeInfo::Top,
+                            1 => VerificationTypeInfo::Integer,
+                            2 => VerificationTypeInfo::Float,
+                            3 => VerificationTypeInfo::Double,
+                            4 => VerificationTypeInfo::Long,
+                            5 => VerificationTypeInfo::Null,
+                            6 => VerificationTypeInfo::UninitializedThis,
+                            7 => {
+                                let class = reader.take::<u16>()?;
+                                VerificationTypeInfo::Object {
+                                    class: class.into(),
+                                }
+                            }
+                            8 => {
+                                let offset = reader.take::<u16>()?;
+                                VerificationTypeInfo::Uninitialized { offset }
+                            }
+                            _ => return Err(BytecodeError::UnsupportedVerificationType),
+                        };
+                        locals.push(verification_type);
+                    }
+                    let number_of_stack_items = reader.take::<u16>()?;
+                    let mut stack = Vec::with_capacity(number_of_stack_items as usize);
+                    for _ in 0..number_of_stack_items {
+                        let verification_type = reader.take::<u8>()?;
+                        let verification_type = match verification_type {
+                            0 => VerificationTypeInfo::Top,
+                            1 => VerificationTypeInfo::Integer,
+                            2 => VerificationTypeInfo::Float,
+                            3 => VerificationTypeInfo::Double,
+                            4 => VerificationTypeInfo::Long,
+                            5 => VerificationTypeInfo::Null,
+                            6 => VerificationTypeInfo::UninitializedThis,
+                            7 => {
+                                let class = reader.take::<u16>()?;
+                                VerificationTypeInfo::Object {
+                                    class: class.into(),
+                                }
+                            }
+                            8 => {
+                                let offset = reader.take::<u16>()?;
+                                VerificationTypeInfo::Uninitialized { offset }
+                            }
+                            _ => return Err(BytecodeError::UnsupportedVerificationType),
+                        };
+                        stack.push(verification_type);
+                    }
+                    StackMapFrame::FullFrame {
+                        frame_type,
+                        number_of_locals,
+                        number_of_stack_items,
+                        offset_delta,
+                        locals,
+                        stack,
+                    }
+                }
+                _ => return Err(BytecodeError::InvalidData),
+            };
+
+            entries.push(entry);
+        }
+
+        Ok(Box::new(StackMapTableInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            number_of_entries,
+            entries,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ExceptionsAttributeFactory;
+
+impl AttributeFactory for ExceptionsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let number_of_exceptions = reader.take::<u16>()?;
+        let mut exception_index_table = Vec::with_capacity(number_of_exceptions as usize);
+        for _ in 0..number_of_exceptions {
+            let exception_index = reader.take::<u16>()?;
+            exception_index_table.push(ConstantPoolIndex::new(exception_index));
+        }
+
+        Ok(Box::new(ExceptionsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            number_of_exceptions,
+            exception_index_table,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct InnerClassesAttributeFactory;
+
+impl AttributeFactory for InnerClassesAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let number_of_classes = reader.take::<u16>()?;
+        let mut classes = Vec::with_capacity(number_of_classes as usize);
+        for _ in 0..number_of_classes {
+            let inner_class_info_index = reader.take::<u16>()?;
+            let outer_class_info_index = reader.take::<u16>()?;
+            let inner_name_index = reader.take::<u16>()?;
+            let inner_class_access_flags = reader.take::<u16>()?;
+            let Some(inner_class_access_flags) =
+                InnerClassAccessFlags::from_bits(inner_class_access_flags)
+            else {
+                return Err(BytecodeError::InvalidData);
+            };
+            classes.push(InnerClass {
+                inner_class_info_index: ConstantPoolIndex::new(inner_class_info_index),
+                outer_class_info_index: ConstantPoolIndex::new(outer_class_info_index),
+                inner_name_index: ConstantPoolIndex::new(inner_name_index),
+                inner_class_access_flags,
+            });
+        }
+
+        Ok(Box::new(InnerClassesInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            number_of_classes,
+            classes,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct EnclosingMethodAttributeFactory;
+
+impl AttributeFactory for EnclosingMethodAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let class_index = reader.take::<u16>()?;
+        let method_index = reader.take::<u16>()?;
+
+        Ok(Box::new(EnclosingMethodInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            class_index: ConstantPoolIndex::new(class_index),
+            method_index: ConstantPoolIndex::new(method_index),
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct SyntheticAttributeFactory;
+
+impl AttributeFactory for SyntheticAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+
+        Ok(Box::new(SyntheticInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct SignatureAttributeFactory;
+
+impl AttributeFactory for SignatureAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let signature_index = reader.take::<u16>()?;
+
+        Ok(Box::new(SignatureInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            signature_index: ConstantPoolIndex::new(signature_index),
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceFileAttributeFactory;
+
+impl AttributeFactory for SourceFileAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let sourcefile_index = reader.take::<u16>()?;
+
+        Ok(Box::new(SourceFileInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            sourcefile_index: ConstantPoolIndex::new(sourcefile_index),
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceDebugExtensionAttributeFactory;
+
+impl AttributeFactory for SourceDebugExtensionAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let debug_extension = reader.take::<Vec<u8>>()?;
+
+        Ok(Box::new(SourceDebugExtensionInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            debug_extension,
+        }))
+    }
+}
+
+impl AttributeFactory for LineNumberTableAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let line_number_table_length = reader.take::<u16>()?;
+        let mut line_number_table = Vec::with_capacity(line_number_table_length as usize);
+        for _ in 0..line_number_table_length {
+            let start_pc = reader.take::<u16>()?;
+            let line_number = reader.take::<u16>()?;
+            line_number_table.push(LineNumberTableEntry {
+                start_pc,
+                line_number,
+            });
+        }
+
+        Ok(Box::new(LineNumberTableInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            line_number_table_length,
+            line_number_table,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalVariableTableAttributeFactory;
+
+impl AttributeFactory for LocalVariableTableAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let local_variable_table_length = reader.take::<u16>()?;
+        let mut local_variable_table = Vec::with_capacity(local_variable_table_length as usize);
+        for _ in 0..local_variable_table_length {
+            let start_pc = reader.take::<u16>()?;
+            let length = reader.take::<u16>()?;
+            let name_index = reader.take::<u16>()?;
+            let descriptor_index = reader.take::<u16>()?;
+            let index = reader.take::<u16>()?;
+            local_variable_table.push(LocalVariableTableEntry {
+                start_pc,
+                length,
+                name_index: ConstantPoolIndex::new(name_index),
+                descriptor_index: ConstantPoolIndex::new(descriptor_index),
+                index: ConstantPoolIndex::new(index),
+            });
+        }
+
+        Ok(Box::new(LocalVariableTableInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            local_variable_table_length,
+            local_variable_table,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalVariableTypeTableAttributeFactory;
+
+impl AttributeFactory for LocalVariableTypeTableAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let local_variable_type_table_length = reader.take::<u16>()?;
+        let mut local_variable_type_table =
+            Vec::with_capacity(local_variable_type_table_length as usize);
+        for _ in 0..local_variable_type_table_length {
+            let start_pc = reader.take::<u16>()?;
+            let length = reader.take::<u16>()?;
+            let name_index = reader.take::<u16>()?;
+            let signature_index = reader.take::<u16>()?;
+            let index = reader.take::<u16>()?;
+            local_variable_type_table.push(LocalVariableTypeTableEntry {
+                start_pc,
+                length,
+                name_index: ConstantPoolIndex::new(name_index),
+                signature_index: ConstantPoolIndex::new(signature_index),
+                index: ConstantPoolIndex::new(index),
+            });
+        }
+
+        Ok(Box::new(LocalVariableTypeTableInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            local_variable_type_table_length,
+            local_variable_type_table,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct DeprecatedAttributeFactory;
+
+impl AttributeFactory for DeprecatedAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+
+        Ok(Box::new(DeprecatedInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeVisibleAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeVisibleAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_annotations = reader.take::<u16>()?;
+        let mut annotations = Vec::with_capacity(num_annotations as usize);
+        for _ in 0..num_annotations {
+            let annotation = read_annotation(reader, pool)?;
+            annotations.push(annotation);
+        }
+
+        Ok(Box::new(RuntimeVisibleAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_annotations,
+            annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeInvisibleAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeInvisibleAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_annotations = reader.take::<u16>()?;
+        let mut annotations = Vec::with_capacity(num_annotations as usize);
+        for _ in 0..num_annotations {
+            let annotation = read_annotation(reader, pool)?;
+            annotations.push(annotation);
+        }
+
+        Ok(Box::new(RuntimeInvisibleAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_annotations,
+            annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeVisibleParameterAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeVisibleParameterAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_parameters = reader.take::<u8>()?;
+        let mut annotations = Vec::with_capacity(num_parameters as usize);
+        for _ in 0..num_parameters {
+            let num_annotations = reader.take::<u16>()?;
+            let mut parameter_annotations = Vec::with_capacity(num_annotations as usize);
+            for _ in 0..num_annotations {
+                let annotation = read_annotation(reader, pool)?;
+                parameter_annotations.push(annotation);
+            }
+            annotations.push(ParameterAnnotation {
+                num_annotations,
+                annotations: parameter_annotations,
+            });
+        }
+
+        Ok(Box::new(RuntimeVisibleParameterAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_parameters,
+            parameter_annotations: annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeInvisibleParameterAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeInvisibleParameterAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_parameters = reader.take::<u8>()?;
+        let mut annotations = Vec::with_capacity(num_parameters as usize);
+        for _ in 0..num_parameters {
+            let num_annotations = reader.take::<u16>()?;
+            let mut parameter_annotations = Vec::with_capacity(num_annotations as usize);
+            for _ in 0..num_annotations {
+                let annotation = read_annotation(reader, pool)?;
+                parameter_annotations.push(annotation);
+            }
+            annotations.push(ParameterAnnotation {
+                num_annotations,
+                annotations: parameter_annotations,
+            });
+        }
+
+        Ok(Box::new(RuntimeInvisibleParameterAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_parameters,
+            parameter_annotations: annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeVisibleTypeAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeVisibleTypeAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_annotations = reader.take::<u16>()?;
+        let mut annotations = Vec::with_capacity(num_annotations as usize);
+        for _ in 0..num_annotations {
+            let annotation = read_typeannotation(reader, pool)?;
+            annotations.push(annotation);
+        }
+
+        Ok(Box::new(RuntimeVisibleTypeAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_annotations,
+            annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeInvisibleTypeAnnotationsAttributeFactory;
+
+impl AttributeFactory for RuntimeInvisibleTypeAnnotationsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_annotations = reader.take::<u16>()?;
+        let mut annotations = Vec::with_capacity(num_annotations as usize);
+        for _ in 0..num_annotations {
+            let annotation = read_typeannotation(reader, pool)?;
+            annotations.push(annotation);
+        }
+
+        Ok(Box::new(RuntimeInvisibleTypeAnnotationsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_annotations,
+            annotations,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct BootstrapMethodsAttributeFactory;
+
+impl AttributeFactory for BootstrapMethodsAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let num_bootstrap_methods = reader.take::<u16>()?;
+        let mut bootstrap_methods = Vec::with_capacity(num_bootstrap_methods as usize);
+        for _ in 0..num_bootstrap_methods {
+            let bootstrap_method_ref = reader.take::<u16>()?;
+            let num_bootstrap_arguments = reader.take::<u16>()?;
+            let mut bootstrap_arguments = Vec::with_capacity(num_bootstrap_arguments as usize);
+            for _ in 0..num_bootstrap_arguments {
+                let bootstrap_argument = reader.take::<u16>()?;
+                bootstrap_arguments.push(ConstantPoolIndex::new(bootstrap_argument));
+            }
+            bootstrap_methods.push(BootstrapMethod {
+                bootstrap_method_ref: ConstantPoolIndex::new(bootstrap_method_ref),
+                num_bootstrap_arguments,
+                bootstrap_arguments,
+            });
+        }
+
+        Ok(Box::new(BootstrapMethodsInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            num_bootstrap_methods,
+            bootstrap_methods,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct AnnotationDefaultAttributeFactory;
+
+impl AttributeFactory for AnnotationDefaultAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let default_value = read_elementvalue(reader, pool)?;
+
+        Ok(Box::new(AnnotationDefaultInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            default_value,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct MethodParametersAttributeFactory;
+
+impl AttributeFactory for MethodParametersAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let parameters_count = reader.take::<u8>()?;
+        let mut parameters = Vec::with_capacity(parameters_count as usize);
+        for _ in 0..parameters_count {
+            let name_index = reader.take::<u16>()?;
+            let access_flags = reader.take::<u16>()?;
+            parameters.push(MethodParameter {
+                name_index: ConstantPoolIndex::new(name_index),
+                access_flags,
+            });
+        }
+
+        Ok(Box::new(MethodParametersInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            parameters_count,
+            parameters,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ModuleAttributeFactory;
+
+impl AttributeFactory for ModuleAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let name_index = reader.take::<u16>()?;
+        let access_flags = reader.take::<u16>()?;
+        let version_index = reader.take::<u16>()?;
+        let requires_count = reader.take::<u16>()?;
+        let mut requires = Vec::with_capacity(requires_count as usize);
+        for _ in 0..requires_count {
+            let requires_index = reader.take::<u16>()?;
+            let requires_flags = reader.take::<u16>()?;
+            let requires_version_index = reader.take::<u16>()?;
+            requires.push(Requires {
+                requires_index: ConstantPoolIndex::new(requires_index),
+                requires_flags,
+                requires_version_index: ConstantPoolIndex::new(requires_version_index),
+            });
+        }
+
+        let exports_count = reader.take::<u16>()?;
+        let mut exports = Vec::with_capacity(exports_count as usize);
+        for _ in 0..exports_count {
+            let exports_index = reader.take::<u16>()?;
+            let exports_flags = reader.take::<u16>()?;
+            let exports_to_count = reader.take::<u16>()?;
+            let mut indices = Vec::with_capacity(exports_to_count as usize);
+            for _ in 0..exports_to_count {
+                let result = reader.take::<u16>()?;
+                indices.push(ConstantPoolIndex::new(result));
+            }
+            exports.push(Exports {
+                exports_index: ConstantPoolIndex::new(exports_index),
+                exports_flags,
+                exports_to_count,
+                exports_to_index: indices,
+            });
+        }
+
+        let opens_count = reader.take::<u16>()?;
+        let mut opens = Vec::with_capacity(opens_count as usize);
+        for _ in 0..opens_count {
+            let opens_index = reader.take::<u16>()?;
+            let opens_flags = reader.take::<u16>()?;
+            let opens_to_count = reader.take::<u16>()?;
+            let mut indices = Vec::with_capacity(opens_to_count as usize);
+            for _ in 0..opens_to_count {
+                let result = reader.take::<u16>()?;
+                indices.push(ConstantPoolIndex::new(result));
+            }
+            opens.push(Opens {
+                opens_index: ConstantPoolIndex::new(opens_index),
+                opens_flags,
+                opens_to_count,
+                opens_to_index: indices,
+            });
+        }
+
+        let uses_count = reader.take::<u16>()?;
+        let mut uses_index = Vec::with_capacity(uses_count as usize);
+        for _ in 0..uses_count {
+            let result = reader.take::<u16>()?;
+            uses_index.push(ConstantPoolIndex::new(result));
+        }
+
+        let provides_count = reader.take::<u16>()?;
+        let mut provides = Vec::with_capacity(provides_count as usize);
+        for _ in 0..provides_count {
+            let provides_index = reader.take::<u16>()?;
+            let provides_with_count = reader.take::<u16>()?;
+            let mut indices = Vec::with_capacity(provides_with_count as usize);
+            for _ in 0..provides_with_count {
+                let result = reader.take::<u16>()?;
+                indices.push(ConstantPoolIndex::new(result));
+            }
+            provides.push(Provides {
+                provides_index: ConstantPoolIndex::new(provides_index),
+                provides_with_count,
+                provides_with_index: indices,
+            });
+        }
+
+        Ok(Box::new(ModuleInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            module_flags: access_flags,
+            module_name_index: ConstantPoolIndex::new(name_index),
+            module_version_index: ConstantPoolIndex::new(version_index),
+            requires_count,
+            requires,
+            exports_count,
+            exports,
+            opens_count,
+            opens,
+            uses_count,
+            uses_index,
+            provides_count,
+            provides,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ModulePackagesAttributeFactory;
+
+impl AttributeFactory for ModulePackagesAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let package_count = reader.take::<u16>()?;
+        let mut package_index = Vec::with_capacity(package_count as usize);
+        for _ in 0..package_count {
+            let result = reader.take::<u16>()?;
+            package_index.push(ConstantPoolIndex::new(result));
+        }
+
+        Ok(Box::new(ModulePackagesInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            package_count,
+            package_index,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ModuleMainClassAttributeFactory;
+
+impl AttributeFactory for ModuleMainClassAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let main_class_index = reader.take::<u16>()?;
+
+        Ok(Box::new(ModuleMainClassInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            main_class_index: ConstantPoolIndex::new(main_class_index),
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct NestHostAttributeFactory;
+
+impl AttributeFactory for NestHostAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let host_class_index = reader.take::<u16>()?;
+
+        Ok(Box::new(NestHostInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            host_class_index: ConstantPoolIndex::new(host_class_index),
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct NestMembersAttributeFactory;
+
+impl AttributeFactory for NestMembersAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        _pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let number_of_classes = reader.take::<u16>()?;
+        let mut classes = Vec::with_capacity(number_of_classes as usize);
+        for _ in 0..number_of_classes {
+            let idx = reader.take::<u16>()?;
+            classes.push(ConstantPoolIndex::new(idx));
+        }
+
+        Ok(Box::new(NestMembersInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            number_of_classes,
+            classes,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RecordAttributeFactory;
+
+impl AttributeFactory for RecordAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let component_count = reader.take::<u16>()?;
+        let mut attributes = Vec::with_capacity(component_count as usize);
+        for _ in 0..component_count {
+            let attr = read_attribute(reader, pool, container)?;
+            attributes.push(attr);
+        }
+
+        Ok(Box::new(RecordInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            component_count,
+            components: attributes,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct PermittedSubtypesAttributeFactory;
+
+impl AttributeFactory for PermittedSubtypesAttributeFactory {
+    fn make(
+        &self,
+        reader: &mut BufferedReader,
+        pool: &mut ConstantPool,
+        _container: &Container,
+    ) -> Result<Box<dyn AnyAttribute>, BytecodeError> {
+        let attribute_name_index = reader.take::<u16>()?;
+        let attribute_length = reader.take::<u32>()?;
+        let number_of_classes = reader.take::<u16>()?;
+        let mut classes = Vec::with_capacity(number_of_classes as usize);
+        for _ in 0..number_of_classes {
+            let class_index = reader.take::<u16>()?;
+            let Some(class) = pool.text_of(class_index.into()) else {
+                return Err(BytecodeError::InvalidData);
+            };
+            classes.push(class);
+        }
+
+        Ok(Box::new(PermittedSubtypesInfo {
+            attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
+            attribute_length,
+            number_of_classes,
+            classes,
+        }))
+    }
+}
+
+fn read_typepath(
+    reader: &mut BufferedReader,
+    _cp: &mut ConstantPool,
+) -> Result<TypePath, BytecodeError> {
+    let path_length = reader.take::<u8>()?;
+    let mut path = Vec::with_capacity(path_length as usize);
+    for _ in 0..path_length {
+        let type_path_kind = reader.take::<u8>()?;
+        let type_argument_index = reader.take::<u8>()?;
+        path.push(TypePathEntry {
+            type_path_kind,
+            type_argument_index: ConstantPoolIndex::new(type_argument_index),
+        });
+    }
+
+    Ok(TypePath { path_length, path })
+}
+
 #[allow(clippy::only_used_in_recursion)]
 fn read_elementvalue(
     reader: &mut BufferedReader,
@@ -342,935 +1365,4 @@ fn read_elementvalue(
     };
 
     Ok(value)
-}
-
-fn read_typeannotation(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<TypeAnnotation, BytecodeError> {
-    let target_type = reader.take::<u8>()?;
-    let target_info = read_typeannotationtarget_info(reader, cp)?;
-    let target_path = read_typepath(reader, cp)?;
-    let type_index = reader.take::<u16>()?;
-    let num_element_value_pairs = reader.take::<u16>()?;
-    let mut element_value_pairs = Vec::with_capacity(num_element_value_pairs as usize);
-    for _ in 0..num_element_value_pairs {
-        let element_name_index = reader.take::<u16>()?;
-        let element_value = read_elementvalue(reader, cp)?;
-        element_value_pairs.push(ElementValuePair {
-            element_name_index: ConstantPoolIndex::new(element_name_index),
-            value: element_value,
-        });
-    }
-
-    Ok(TypeAnnotation {
-        target_type,
-        target_info,
-        target_path,
-        type_index: ConstantPoolIndex::new(type_index),
-        num_element_value_pairs,
-        element_value_pairs,
-    })
-}
-
-fn read_constantvalue_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<ConstantValueInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let constantvalue_index = reader.take::<u16>()?;
-
-    Ok(ConstantValueInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        constantvalue_index: ConstantPoolIndex::new(constantvalue_index),
-    })
-}
-
-fn read_code_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<CodeInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let max_stack = reader.take::<u16>()?;
-    let max_locals = reader.take::<u16>()?;
-    let code_length = reader.take::<u32>()?;
-    let code = reader.take_bytes(code_length as usize)?;
-    let exception_table_length = reader.take::<u16>()?;
-    let mut exception_table = Vec::with_capacity(exception_table_length as usize);
-    for _ in 0..exception_table_length {
-        let start_pc = reader.take::<u16>()?;
-        let end_pc = reader.take::<u16>()?;
-        let handler_pc = reader.take::<u16>()?;
-        let catch_type = reader.take::<u16>()?;
-        exception_table.push(ExceptionTableEntry {
-            start_pc,
-            end_pc,
-            handler_pc,
-            catch_type: ConstantPoolIndex::new(catch_type),
-        });
-    }
-    let attributes_count = reader.take::<u16>()?;
-    let mut attributes = Vec::with_capacity(attributes_count as usize);
-    for _ in 0..attributes_count {
-        let attribute = read_attribute(reader, cp)?;
-        attributes.push(attribute);
-    }
-
-    Ok(CodeInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        max_stack,
-        max_locals,
-        code_length,
-        code: code.to_vec(),
-        exception_table_length,
-        exception_table,
-        attributes_count,
-        attributes,
-    })
-}
-
-fn read_stackmaptable_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<StackMapTableInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_entries = reader.take::<u16>()?;
-    let frame_type = reader.take::<u8>()?;
-    let mut entries = Vec::with_capacity(number_of_entries as usize);
-    for _ in 0..number_of_entries {
-        let entry = match frame_type {
-            0..=63 => StackMapFrame::SameFrame { frame_type },
-            64..=127 => {
-                let verification_type = reader.take::<u8>()?;
-                let verification_type = match verification_type {
-                    0 => VerificationTypeInfo::Top,
-                    1 => VerificationTypeInfo::Integer,
-                    2 => VerificationTypeInfo::Float,
-                    3 => VerificationTypeInfo::Double,
-                    4 => VerificationTypeInfo::Long,
-                    5 => VerificationTypeInfo::Null,
-                    6 => VerificationTypeInfo::UninitializedThis,
-                    7 => {
-                        let class = reader.take::<u16>()?;
-                        VerificationTypeInfo::Object {
-                            class: class.into(),
-                        }
-                    }
-                    8 => {
-                        let offset = reader.take::<u16>()?;
-                        VerificationTypeInfo::Uninitialized { offset }
-                    }
-                    _ => return Err(BytecodeError::UnsupportedVerificationType),
-                };
-                StackMapFrame::SameLocals1StackItemFrame {
-                    frame_type,
-                    stack: verification_type,
-                }
-            }
-            247 => {
-                let offset_delta = reader.take::<u16>()?;
-                let verification_type = reader.take::<u8>()?;
-                let verification_type = match verification_type {
-                    0 => VerificationTypeInfo::Top,
-                    1 => VerificationTypeInfo::Integer,
-                    2 => VerificationTypeInfo::Float,
-                    3 => VerificationTypeInfo::Double,
-                    4 => VerificationTypeInfo::Long,
-                    5 => VerificationTypeInfo::Null,
-                    6 => VerificationTypeInfo::UninitializedThis,
-                    7 => {
-                        let class = reader.take::<u16>()?;
-                        VerificationTypeInfo::Object {
-                            class: class.into(),
-                        }
-                    }
-                    8 => {
-                        let offset = reader.take::<u16>()?;
-                        VerificationTypeInfo::Uninitialized { offset }
-                    }
-                    _ => return Err(BytecodeError::UnsupportedVerificationType),
-                };
-
-                StackMapFrame::SameLocals1StackItemFrameExtended {
-                    frame_type,
-                    offset_delta,
-                    stack: verification_type,
-                }
-            }
-            248..=250 => {
-                let offset_delta = reader.take::<u16>()?;
-                StackMapFrame::ChopFrame {
-                    frame_type,
-                    offset_delta,
-                }
-            }
-            251 => {
-                let offset_delta = reader.take::<u16>()?;
-                StackMapFrame::SameFrameExtended {
-                    frame_type,
-                    offset_delta,
-                }
-            }
-            252..=254 => {
-                let offset_delta = reader.take::<u16>()?;
-                let mut locals = Vec::with_capacity(frame_type as usize - 251);
-                for _ in 0..frame_type - 251 {
-                    let verification_type = reader.take::<u8>()?;
-                    let verification_type = match verification_type {
-                        0 => VerificationTypeInfo::Top,
-                        1 => VerificationTypeInfo::Integer,
-                        2 => VerificationTypeInfo::Float,
-                        3 => VerificationTypeInfo::Double,
-                        4 => VerificationTypeInfo::Long,
-                        5 => VerificationTypeInfo::Null,
-                        6 => VerificationTypeInfo::UninitializedThis,
-                        7 => {
-                            let class = reader.take::<u16>()?;
-                            VerificationTypeInfo::Object {
-                                class: class.into(),
-                            }
-                        }
-                        8 => {
-                            let offset = reader.take::<u16>()?;
-                            VerificationTypeInfo::Uninitialized { offset }
-                        }
-                        _ => return Err(BytecodeError::UnsupportedVerificationType),
-                    };
-                    locals.push(verification_type);
-                }
-                StackMapFrame::AppendFrame {
-                    frame_type,
-                    offset_delta,
-                    locals,
-                }
-            }
-            255 => {
-                let offset_delta = reader.take::<u16>()?;
-                let number_of_locals = reader.take::<u16>()?;
-                let mut locals = Vec::with_capacity(number_of_locals as usize);
-                for _ in 0..number_of_locals {
-                    let verification_type = reader.take::<u8>()?;
-                    let verification_type = match verification_type {
-                        0 => VerificationTypeInfo::Top,
-                        1 => VerificationTypeInfo::Integer,
-                        2 => VerificationTypeInfo::Float,
-                        3 => VerificationTypeInfo::Double,
-                        4 => VerificationTypeInfo::Long,
-                        5 => VerificationTypeInfo::Null,
-                        6 => VerificationTypeInfo::UninitializedThis,
-                        7 => {
-                            let class = reader.take::<u16>()?;
-                            VerificationTypeInfo::Object {
-                                class: class.into(),
-                            }
-                        }
-                        8 => {
-                            let offset = reader.take::<u16>()?;
-                            VerificationTypeInfo::Uninitialized { offset }
-                        }
-                        _ => return Err(BytecodeError::UnsupportedVerificationType),
-                    };
-                    locals.push(verification_type);
-                }
-                let number_of_stack_items = reader.take::<u16>()?;
-                let mut stack = Vec::with_capacity(number_of_stack_items as usize);
-                for _ in 0..number_of_stack_items {
-                    let verification_type = reader.take::<u8>()?;
-                    let verification_type = match verification_type {
-                        0 => VerificationTypeInfo::Top,
-                        1 => VerificationTypeInfo::Integer,
-                        2 => VerificationTypeInfo::Float,
-                        3 => VerificationTypeInfo::Double,
-                        4 => VerificationTypeInfo::Long,
-                        5 => VerificationTypeInfo::Null,
-                        6 => VerificationTypeInfo::UninitializedThis,
-                        7 => {
-                            let class = reader.take::<u16>()?;
-                            VerificationTypeInfo::Object {
-                                class: class.into(),
-                            }
-                        }
-                        8 => {
-                            let offset = reader.take::<u16>()?;
-                            VerificationTypeInfo::Uninitialized { offset }
-                        }
-                        _ => return Err(BytecodeError::UnsupportedVerificationType),
-                    };
-                    stack.push(verification_type);
-                }
-                StackMapFrame::FullFrame {
-                    frame_type,
-                    number_of_locals,
-                    number_of_stack_items,
-                    offset_delta,
-                    locals,
-                    stack,
-                }
-            }
-            _ => return Err(BytecodeError::InvalidData),
-        };
-
-        entries.push(entry);
-    }
-
-    Ok(StackMapTableInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        number_of_entries,
-        entries,
-    })
-}
-
-fn read_exceptions_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<ExceptionsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_exceptions = reader.take::<u16>()?;
-    let mut exception_index_table = Vec::with_capacity(number_of_exceptions as usize);
-    for _ in 0..number_of_exceptions {
-        let exception_index = reader.take::<u16>()?;
-        exception_index_table.push(ConstantPoolIndex::new(exception_index));
-    }
-
-    Ok(ExceptionsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        number_of_exceptions,
-        exception_index_table,
-    })
-}
-
-fn read_innerclasses_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<InnerClassesInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_classes = reader.take::<u16>()?;
-    let mut classes = Vec::with_capacity(number_of_classes as usize);
-    for _ in 0..number_of_classes {
-        let inner_class_info_index = reader.take::<u16>()?;
-        let outer_class_info_index = reader.take::<u16>()?;
-        let inner_name_index = reader.take::<u16>()?;
-        let inner_class_access_flags = reader.take::<u16>()?;
-        let Some(inner_class_access_flags) =
-            InnerClassAccessFlags::from_bits(inner_class_access_flags)
-        else {
-            return Err(BytecodeError::InvalidData);
-        };
-        classes.push(InnerClass {
-            inner_class_info_index: ConstantPoolIndex::new(inner_class_info_index),
-            outer_class_info_index: ConstantPoolIndex::new(outer_class_info_index),
-            inner_name_index: ConstantPoolIndex::new(inner_name_index),
-            inner_class_access_flags,
-        });
-    }
-
-    Ok(InnerClassesInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        number_of_classes,
-        classes,
-    })
-}
-
-fn read_enclosingmethod_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<EnclosingMethodInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let class_index = reader.take::<u16>()?;
-    let method_index = reader.take::<u16>()?;
-
-    Ok(EnclosingMethodInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        class_index: ConstantPoolIndex::new(class_index),
-        method_index: ConstantPoolIndex::new(method_index),
-    })
-}
-
-fn read_synthetic_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<SyntheticInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-
-    Ok(SyntheticInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-    })
-}
-
-fn read_signature_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<SignatureInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let signature_index = reader.take::<u16>()?;
-
-    Ok(SignatureInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        signature_index: ConstantPoolIndex::new(signature_index),
-    })
-}
-
-fn read_sourcefile_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<SourceFileInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let sourcefile_index = reader.take::<u16>()?;
-
-    Ok(SourceFileInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        sourcefile_index: ConstantPoolIndex::new(sourcefile_index),
-    })
-}
-
-fn read_sourcedebugextension_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<SourceDebugExtensionInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let debug_extension = reader.take::<Vec<u8>>()?;
-
-    Ok(SourceDebugExtensionInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        debug_extension,
-    })
-}
-
-fn read_linenumbertable_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<LineNumberTableInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let line_number_table_length = reader.take::<u16>()?;
-    let mut line_number_table = Vec::with_capacity(line_number_table_length as usize);
-    for _ in 0..line_number_table_length {
-        let start_pc = reader.take::<u16>()?;
-        let line_number = reader.take::<u16>()?;
-        line_number_table.push(LineNumberTableEntry {
-            start_pc,
-            line_number,
-        });
-    }
-
-    Ok(LineNumberTableInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        line_number_table_length,
-        line_number_table,
-    })
-}
-
-fn read_localvariabletable_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<LocalVariableTableInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let local_variable_table_length = reader.take::<u16>()?;
-    let mut local_variable_table = Vec::with_capacity(local_variable_table_length as usize);
-    for _ in 0..local_variable_table_length {
-        let start_pc = reader.take::<u16>()?;
-        let length = reader.take::<u16>()?;
-        let name_index = reader.take::<u16>()?;
-        let descriptor_index = reader.take::<u16>()?;
-        let index = reader.take::<u16>()?;
-        local_variable_table.push(LocalVariableTableEntry {
-            start_pc,
-            length,
-            name_index: ConstantPoolIndex::new(name_index),
-            descriptor_index: ConstantPoolIndex::new(descriptor_index),
-            index: ConstantPoolIndex::new(index),
-        });
-    }
-
-    Ok(LocalVariableTableInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        local_variable_table_length,
-        local_variable_table,
-    })
-}
-
-fn read_localvariabletypetable_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<LocalVariableTypeTableInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let local_variable_type_table_length = reader.take::<u16>()?;
-    let mut local_variable_type_table =
-        Vec::with_capacity(local_variable_type_table_length as usize);
-    for _ in 0..local_variable_type_table_length {
-        let start_pc = reader.take::<u16>()?;
-        let length = reader.take::<u16>()?;
-        let name_index = reader.take::<u16>()?;
-        let signature_index = reader.take::<u16>()?;
-        let index = reader.take::<u16>()?;
-        local_variable_type_table.push(LocalVariableTypeTableEntry {
-            start_pc,
-            length,
-            name_index: ConstantPoolIndex::new(name_index),
-            signature_index: ConstantPoolIndex::new(signature_index),
-            index: ConstantPoolIndex::new(index),
-        });
-    }
-
-    Ok(LocalVariableTypeTableInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        local_variable_type_table_length,
-        local_variable_type_table,
-    })
-}
-
-fn read_deprecated_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<DeprecatedInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-
-    Ok(DeprecatedInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-    })
-}
-
-fn read_runtimevisibleannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeVisibleAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_annotations = reader.take::<u16>()?;
-    let mut annotations = Vec::with_capacity(num_annotations as usize);
-    for _ in 0..num_annotations {
-        let annotation = read_annotation(reader, cp)?;
-        annotations.push(annotation);
-    }
-
-    Ok(RuntimeVisibleAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_annotations,
-        annotations,
-    })
-}
-
-fn read_runtimeinvisibleannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeInvisibleAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_annotations = reader.take::<u16>()?;
-    let mut annotations = Vec::with_capacity(num_annotations as usize);
-    for _ in 0..num_annotations {
-        let annotation = read_annotation(reader, cp)?;
-        annotations.push(annotation);
-    }
-
-    Ok(RuntimeInvisibleAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_annotations,
-        annotations,
-    })
-}
-
-fn read_runtimevisibleparameterannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeVisibleParameterAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_parameters = reader.take::<u8>()?;
-    let mut annotations = Vec::with_capacity(num_parameters as usize);
-    for _ in 0..num_parameters {
-        let num_annotations = reader.take::<u16>()?;
-        let mut parameter_annotations = Vec::with_capacity(num_annotations as usize);
-        for _ in 0..num_annotations {
-            let annotation = read_annotation(reader, cp)?;
-            parameter_annotations.push(annotation);
-        }
-        annotations.push(ParameterAnnotation {
-            num_annotations,
-            annotations: parameter_annotations,
-        });
-    }
-
-    Ok(RuntimeVisibleParameterAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_parameters,
-        parameter_annotations: annotations,
-    })
-}
-
-fn read_runtimeinvisibleparameterannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeInvisibleParameterAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_parameters = reader.take::<u8>()?;
-    let mut annotations = Vec::with_capacity(num_parameters as usize);
-    for _ in 0..num_parameters {
-        let num_annotations = reader.take::<u16>()?;
-        let mut parameter_annotations = Vec::with_capacity(num_annotations as usize);
-        for _ in 0..num_annotations {
-            let annotation = read_annotation(reader, cp)?;
-            parameter_annotations.push(annotation);
-        }
-        annotations.push(ParameterAnnotation {
-            num_annotations,
-            annotations: parameter_annotations,
-        });
-    }
-
-    Ok(RuntimeInvisibleParameterAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_parameters,
-        parameter_annotations: annotations,
-    })
-}
-
-fn read_runtimevisibletypeannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeVisibleTypeAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_annotations = reader.take::<u16>()?;
-    let mut annotations = Vec::with_capacity(num_annotations as usize);
-    for _ in 0..num_annotations {
-        let annotation = read_typeannotation(reader, cp)?;
-        annotations.push(annotation);
-    }
-
-    Ok(RuntimeVisibleTypeAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_annotations,
-        annotations,
-    })
-}
-
-fn read_runtimeinvisibletypeannotations_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RuntimeInvisibleTypeAnnotationsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_annotations = reader.take::<u16>()?;
-    let mut annotations = Vec::with_capacity(num_annotations as usize);
-    for _ in 0..num_annotations {
-        let annotation = read_typeannotation(reader, cp)?;
-        annotations.push(annotation);
-    }
-
-    Ok(RuntimeInvisibleTypeAnnotationsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_annotations,
-        annotations,
-    })
-}
-
-fn read_bootstrapmethods_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<BootstrapMethodsInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let num_bootstrap_methods = reader.take::<u16>()?;
-    let mut bootstrap_methods = Vec::with_capacity(num_bootstrap_methods as usize);
-    for _ in 0..num_bootstrap_methods {
-        let bootstrap_method_ref = reader.take::<u16>()?;
-        let num_bootstrap_arguments = reader.take::<u16>()?;
-        let mut bootstrap_arguments = Vec::with_capacity(num_bootstrap_arguments as usize);
-        for _ in 0..num_bootstrap_arguments {
-            let bootstrap_argument = reader.take::<u16>()?;
-            bootstrap_arguments.push(ConstantPoolIndex::new(bootstrap_argument));
-        }
-        bootstrap_methods.push(BootstrapMethod {
-            bootstrap_method_ref: ConstantPoolIndex::new(bootstrap_method_ref),
-            num_bootstrap_arguments,
-            bootstrap_arguments,
-        });
-    }
-
-    Ok(BootstrapMethodsInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        num_bootstrap_methods,
-        bootstrap_methods,
-    })
-}
-
-fn read_methodparameters_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<MethodParametersInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let parameters_count = reader.take::<u8>()?;
-    let mut parameters = Vec::with_capacity(parameters_count as usize);
-    for _ in 0..parameters_count {
-        let name_index = reader.take::<u16>()?;
-        let access_flags = reader.take::<u16>()?;
-        parameters.push(MethodParameter {
-            name_index: ConstantPoolIndex::new(name_index),
-            access_flags,
-        });
-    }
-
-    Ok(MethodParametersInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        parameters_count,
-        parameters,
-    })
-}
-
-fn read_module_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<ModuleInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let name_index = reader.take::<u16>()?;
-    let access_flags = reader.take::<u16>()?;
-    let version_index = reader.take::<u16>()?;
-    let requires_count = reader.take::<u16>()?;
-    let mut requires = Vec::with_capacity(requires_count as usize);
-    for _ in 0..requires_count {
-        let requires_index = reader.take::<u16>()?;
-        let requires_flags = reader.take::<u16>()?;
-        let requires_version_index = reader.take::<u16>()?;
-        requires.push(Requires {
-            requires_index: ConstantPoolIndex::new(requires_index),
-            requires_flags,
-            requires_version_index: ConstantPoolIndex::new(requires_version_index),
-        });
-    }
-
-    let exports_count = reader.take::<u16>()?;
-    let mut exports = Vec::with_capacity(exports_count as usize);
-    for _ in 0..exports_count {
-        let exports_index = reader.take::<u16>()?;
-        let exports_flags = reader.take::<u16>()?;
-        let exports_to_count = reader.take::<u16>()?;
-        let mut indices = Vec::with_capacity(exports_to_count as usize);
-        for _ in 0..exports_to_count {
-            let result = reader.take::<u16>()?;
-            indices.push(ConstantPoolIndex::new(result));
-        }
-        exports.push(Exports {
-            exports_index: ConstantPoolIndex::new(exports_index),
-            exports_flags,
-            exports_to_count,
-            exports_to_index: indices,
-        });
-    }
-
-    let opens_count = reader.take::<u16>()?;
-    let mut opens = Vec::with_capacity(opens_count as usize);
-    for _ in 0..opens_count {
-        let opens_index = reader.take::<u16>()?;
-        let opens_flags = reader.take::<u16>()?;
-        let opens_to_count = reader.take::<u16>()?;
-        let mut indices = Vec::with_capacity(opens_to_count as usize);
-        for _ in 0..opens_to_count {
-            let result = reader.take::<u16>()?;
-            indices.push(ConstantPoolIndex::new(result));
-        }
-        opens.push(Opens {
-            opens_index: ConstantPoolIndex::new(opens_index),
-            opens_flags,
-            opens_to_count,
-            opens_to_index: indices,
-        });
-    }
-
-    let uses_count = reader.take::<u16>()?;
-    let mut uses_index = Vec::with_capacity(uses_count as usize);
-    for _ in 0..uses_count {
-        let result = reader.take::<u16>()?;
-        uses_index.push(ConstantPoolIndex::new(result));
-    }
-
-    let provides_count = reader.take::<u16>()?;
-    let mut provides = Vec::with_capacity(provides_count as usize);
-    for _ in 0..provides_count {
-        let provides_index = reader.take::<u16>()?;
-        let provides_with_count = reader.take::<u16>()?;
-        let mut indices = Vec::with_capacity(provides_with_count as usize);
-        for _ in 0..provides_with_count {
-            let result = reader.take::<u16>()?;
-            indices.push(ConstantPoolIndex::new(result));
-        }
-        provides.push(Provides {
-            provides_index: ConstantPoolIndex::new(provides_index),
-            provides_with_count,
-            provides_with_index: indices,
-        });
-    }
-
-    Ok(ModuleInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        module_flags: access_flags,
-        module_name_index: ConstantPoolIndex::new(name_index),
-        module_version_index: ConstantPoolIndex::new(version_index),
-        requires_count,
-        requires,
-        exports_count,
-        exports,
-        opens_count,
-        opens,
-        uses_count,
-        uses_index,
-        provides_count,
-        provides,
-    })
-}
-
-fn read_modulepackages_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<ModulePackagesInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_packages = reader.take::<u16>()?;
-    let mut packages = Vec::with_capacity(number_of_packages as usize);
-    for _ in 0..number_of_packages {
-        let idx = reader.take::<u16>()?;
-        packages.push(ConstantPoolIndex::new(idx));
-    }
-
-    Ok(ModulePackagesInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        package_count: number_of_packages,
-        package_index: packages,
-    })
-}
-
-fn read_modulemainclass_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<ModuleMainClassInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let main_class_index = reader.take::<u16>()?;
-
-    Ok(ModuleMainClassInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        main_class_index: ConstantPoolIndex::new(main_class_index),
-    })
-}
-
-fn read_nesthost_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<NestHostInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let host_class_index = reader.take::<u16>()?;
-
-    Ok(NestHostInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        host_class_index: ConstantPoolIndex::new(host_class_index),
-    })
-}
-
-fn read_nestmembers_info(
-    reader: &mut BufferedReader,
-    _cp: &mut ConstantPool,
-) -> Result<NestMembersInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_classes = reader.take::<u16>()?;
-    let mut classes = Vec::with_capacity(number_of_classes as usize);
-    for _ in 0..number_of_classes {
-        let idx = reader.take::<u16>()?;
-        classes.push(ConstantPoolIndex::new(idx));
-    }
-
-    Ok(NestMembersInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        number_of_classes,
-        classes,
-    })
-}
-
-fn read_record_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<RecordInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let component_count = reader.take::<u16>()?;
-    let mut attributes = Vec::with_capacity(component_count as usize);
-    for _ in 0..component_count {
-        let attr = read_attribute(reader, cp)?;
-        attributes.push(attr);
-    }
-
-    Ok(RecordInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        component_count,
-        components: attributes,
-    })
-}
-
-fn read_permittedsubtypes_info(
-    reader: &mut BufferedReader,
-    cp: &mut ConstantPool,
-) -> Result<PermittedSubtypesInfo, BytecodeError> {
-    let attribute_name_index = reader.take::<u16>()?;
-    let attribute_length = reader.take::<u32>()?;
-    let number_of_classes = reader.take::<u16>()?;
-    let mut classes = Vec::with_capacity(number_of_classes as usize);
-    for _ in 0..number_of_classes {
-        let class_index = reader.take::<u16>()?;
-        let Some(class) = cp.text_of(class_index.into()) else {
-            return Err(BytecodeError::InvalidData);
-        };
-        classes.push(class);
-    }
-
-    Ok(PermittedSubtypesInfo {
-        attribute_name_index: ConstantPoolIndex::new(attribute_name_index),
-        attribute_length,
-        number_of_classes,
-        classes,
-    })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,2 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,519 @@
+use std::collections::HashMap;
+
+use bytecode::attributes::{
+    element_value_string, MethodParametersInfo, RuntimeInvisibleAnnotationsInfo,
+    RuntimeVisibleAnnotationsInfo,
+};
+use bytecode::DescriptorKind;
+use error::Error;
+
 pub mod bytecode;
 pub mod decoder;
+pub mod error;
 pub mod types;
+
+// -----------------------------------------------------------------------------
+//  - common stuff -
+// -----------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Annotation {
+    /// The name of the annotation.
+    pub name: String,
+    // TODO: change the value type to support other values than just strings
+    pub field: HashMap<String, String>,
+}
+
+impl Annotation {
+    pub fn from_bytecode(
+        bytecode: &bytecode::attributes::Annotation,
+        pool: &bytecode::pool::ConstantPool,
+    ) -> Result<Annotation, Error> {
+        let name = pool.text_of(bytecode.type_index).unwrap();
+        let field = bytecode
+            .element_value_pairs
+            .iter()
+            .map(|pair| {
+                let key = pool.text_of(pair.element_name_index).unwrap();
+                let value = match element_value_string(&pair.value, pool) {
+                    Ok(value) => value,
+                    Err(_) => unreachable!(),
+                };
+                (key, value)
+            })
+            .collect();
+        Ok(Annotation { name, field })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TypeRef {
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub struct Package {
+    /// The name of the package.
+    pub name: String,
+}
+
+// -----------------------------------------------------------------------------
+//  - Method-specific stuff -
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Clone)]
+#[repr(u16)]
+pub enum MethodModifier {
+    Public = 0x0001,
+    Private = 0x0002,
+    Protected = 0x0004,
+
+    Static = 0x0008,
+    Final = 0x0010,
+
+    Synchronized = 0x0020,
+
+    Varargs = 0x0080,
+    Bridge = 0x0040,
+    Native = 0x0100,
+    Abstract = 0x0400,
+    Strict = 0x0800,
+
+    Synthetic = 0x1000,
+    Enum = 0x4000,
+}
+
+impl MethodModifier {
+    /// Returns the bytecode representation of the method modifier.
+    pub fn bytecode(&self) -> u16 {
+        // as stated in the docs, this should return the discriminant value of
+        // the enum, which is the bytecode representation of the method modifier
+        // (e.g. `MethodModifier::Public` should return `0x0001`).
+        // see: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
+        // TODO: check if there is a better (safe) way to do this...
+        unsafe { *(self as *const Self as *const u16) }
+    }
+}
+
+#[derive(Debug)]
+pub struct Parameter {
+    /// The name of the parameter.
+    pub name: Option<String>,
+    /// The position of the parameter within a method parameter's list.
+    pub position: usize,
+    /// The type of the parameter.
+    pub ty: TypeRef,
+}
+
+#[derive(Debug)]
+pub struct MethodBody {}
+
+#[derive(Debug)]
+pub struct Method {
+    /// The name of the method.
+    pub name: String,
+    /// A list of all parameters of the method.
+    pub parameters: Vec<Parameter>,
+    /// The return type of the method.
+    pub ty: Option<TypeRef>,
+    /// A list of all annotations of the method.
+    pub annotations: Vec<Annotation>,
+    /// A list of all modifiers of the method.
+    pub modifiers: Vec<MethodModifier>,
+    /// The body of the method.
+    pub body: Option<MethodBody>,
+}
+
+impl Method {
+    pub fn from_bytecode(
+        bytecode: &bytecode::Method,
+        pool: &bytecode::pool::ConstantPool,
+        // TODO: use a proper error type
+    ) -> Result<Self, Error> {
+        // -----------------------------------------------------------------------------
+        //  - Transform parameters from bytecode representation to IR representation -
+        // -----------------------------------------------------------------------------
+        let attr_params: Vec<String> = bytecode
+            .attributes
+            .get("MethodParameters")
+            .and_then(|attr| attr.as_any_ref().downcast_ref::<MethodParametersInfo>())
+            .map(|params| {
+                params
+                    .parameters
+                    .iter()
+                    .map(|param| pool.text_of(param.name_index).unwrap())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let desc_params = bytecode
+            .descriptor
+            .iter()
+            .filter(|desc| desc.kind == DescriptorKind::Parameter)
+            .collect::<Vec<&bytecode::Descriptor>>();
+
+        let parameters: Vec<Parameter> = desc_params
+            .iter()
+            .enumerate()
+            .map(|(i, desc)| {
+                let name: Option<String> = attr_params.get(i).cloned();
+                let ty = desc.ty.to_string();
+                Parameter {
+                    name,
+                    ty: TypeRef { name: ty },
+                    position: i,
+                }
+            })
+            .collect();
+
+        // -----------------------------------------------------------------------------
+        //  - Extract the method's return type from the bytecode representation -
+        // -----------------------------------------------------------------------------
+        let ret_ty: Option<TypeRef> = bytecode.descriptor.iter().find_map(|desc| {
+            if desc.kind == DescriptorKind::Return {
+                Some(TypeRef {
+                    name: desc.ty.to_string(),
+                })
+            } else {
+                None
+            }
+        });
+
+        // -----------------------------------------------------------------------------
+        //  - Transform annotations from bytecode representation to IR representation -
+        // -----------------------------------------------------------------------------
+        // TODO: we should add support to read only annotations that are available in the
+        // desired JVM specification ...
+        let mut annotations: Vec<Annotation> = vec![];
+        if let Some(attr) =
+            bytecode.get_attribute::<RuntimeVisibleAnnotationsInfo>("RuntimeVisibleAnnotations")
+        {
+            let items: Vec<Annotation> = attr
+                .annotations
+                .iter()
+                .map(|item| Annotation::from_bytecode(item, pool).unwrap())
+                .collect();
+            annotations.extend(items);
+        }
+
+        if let Some(attr) =
+            bytecode.get_attribute::<RuntimeInvisibleAnnotationsInfo>("RuntimeInvisibleAnnotations")
+        {
+            let items: Vec<Annotation> = attr
+                .annotations
+                .iter()
+                .map(|item| Annotation::from_bytecode(item, pool).unwrap())
+                .collect();
+            annotations.extend(items);
+        }
+
+        let method = Method {
+            name: bytecode.name.clone(),
+            parameters,
+            ty: ret_ty,
+            annotations,
+            modifiers: vec![],
+            body: None,
+        };
+
+        Ok(method)
+    }
+}
+
+impl Method {
+    /// Returns the name of the method.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Tries to find a parameter by the given `name`. Returns `None` if no parameter with the given
+    /// `name` can be found.
+    pub fn parameter_by_name(&self, name: &str) -> Option<&Parameter> {
+        self.parameters
+            .iter()
+            .find(|p| p.name.as_deref() == Some(name))
+    }
+
+    /// Tries to find a parameter by the given `index`. Returns `None` if no parameter with the
+    /// given `index` can be found.
+    pub fn parameter_by_index(&self, index: usize) -> Option<&Parameter> {
+        self.parameters.get(index)
+    }
+
+    /// Checks whether the method has a parameter with the given `name`.
+    pub fn has_parameter_by_name(&self, name: &str) -> bool {
+        self.parameters
+            .iter()
+            .any(|p| p.name.as_deref() == Some(name))
+    }
+
+    /// Checks whether the method has a parameter with the given `index`.
+    pub fn has_parameter_by_index(&self, index: usize) -> bool {
+        self.parameters.get(index).is_some()
+    }
+
+    /// Tries to find an annotation by the given `name`. Returns `None` if no annotation with the
+    /// given `name` can be found.
+    pub fn get_annotation_by_name(&self, name: &str) -> Option<&Annotation> {
+        self.annotations.iter().find(|a| a.name == name)
+    }
+
+    /// Tries to find an annotation by the given `index`. Returns `None` if no annotation with the
+    /// given `index` can be found.
+    pub fn get_annotation_by_index(&self, index: usize) -> Option<&Annotation> {
+        self.annotations.get(index)
+    }
+
+    /// Checks whether the method has an annotation with the given `name`.
+    pub fn has_annotation_by_name(&self, name: &str) -> bool {
+        self.annotations.iter().any(|a| a.name == name)
+    }
+
+    /// Checks whether the method has an annotation with the given `index`.
+    pub fn has_annotation_by_index(&self, index: usize) -> bool {
+        self.annotations.get(index).is_some()
+    }
+
+    /// Checks whether the method has the given `modifier`.
+    pub fn has_modifier(&self, modifier: MethodModifier) -> bool {
+        self.modifiers.contains(&modifier)
+    }
+
+    // -----------------------------------------------------------------------------
+    //  - convenience methods -
+    // -----------------------------------------------------------------------------
+
+    /// Convenience method to check whether the method is protected.
+    pub fn is_protected(&self) -> bool {
+        self.modifiers.contains(&MethodModifier::Protected)
+    }
+
+    /// Convenience method to check whether the method is public.
+    pub fn is_public(&self) -> bool {
+        self.modifiers.contains(&MethodModifier::Public)
+    }
+
+    /// Convenience method to check whether the method is private.
+    pub fn is_private(&self) -> bool {
+        self.modifiers.contains(&MethodModifier::Private)
+    }
+
+    /// Convenience method to check whether the method is static.
+    pub fn is_static(&self) -> bool {
+        self.modifiers.contains(&MethodModifier::Static)
+    }
+
+    /// Convenience method to check whether the method is final.
+    pub fn is_final(&self) -> bool {
+        self.modifiers.contains(&MethodModifier::Final)
+    }
+}
+
+// -----------------------------------------------------------------------------
+//  - Field-specific stuff -
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Clone)]
+#[repr(u16)]
+pub enum FieldModifier {
+    Public = 0x0001,
+    Private = 0x0002,
+    Protected = 0x0004,
+
+    Static = 0x0008,
+    Final = 0x0010,
+
+    Volatile = 0x0040,
+    Transient = 0x0080,
+    Synthetic = 0x1000,
+
+    Enum = 0x4000,
+}
+
+impl FieldModifier {
+    /// Returns the bytecode representation of the field modifier.
+    pub fn bytecode(&self) -> u16 {
+        // as stated in the docs, this should return the discriminant value of
+        // the enum, which is the bytecode representation of the field modifier
+        // (e.g. `FieldModifier::Public` should return `0x0001`).
+        // see: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
+        // TODO: check if there is a better (safe) way to do this...
+        unsafe { *(self as *const Self as *const u16) }
+    }
+}
+
+#[derive(Debug)]
+pub struct Field {
+    /// The name of the field.
+    pub name: String,
+    /// The type of the field.
+    pub ty: TypeRef,
+    /// A list of all modifiers of the field.
+    pub modifiers: Vec<FieldModifier>,
+    /// A list of all annotations of the field.
+    pub annotations: Vec<Annotation>,
+}
+
+impl Field {
+    /// Returns the name of the field.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Checks whether the field has the given `modifier`.
+    pub fn has_modifier(&self, modifier: FieldModifier) -> bool {
+        self.modifiers.contains(&modifier)
+    }
+
+    /// Tries to find an annotation by the given `name`. Returns `None` if no annotation with the
+    /// given `name` can be found.
+    pub fn get_annotation_by_name(&self, name: &str) -> Option<&Annotation> {
+        self.annotations.iter().find(|a| a.name == name)
+    }
+
+    /// Tries to find an annotation by the given `index`. Returns `None` if no annotation with the
+    /// given `index` can be found.
+    pub fn get_annotation_by_index(&self, index: usize) -> Option<&Annotation> {
+        self.annotations.get(index)
+    }
+
+    // -----------------------------------------------------------------------------
+    //  - convenience methods -
+    // -----------------------------------------------------------------------------
+
+    /// Convenience method to check whether the field is public.
+    pub fn is_public(&self) -> bool {
+        self.modifiers.contains(&FieldModifier::Public)
+    }
+
+    /// Convenience method to check whether the field is private.
+    pub fn is_private(&self) -> bool {
+        self.modifiers.contains(&FieldModifier::Private)
+    }
+
+    /// Convenience method to check whether the field is protected.
+    pub fn is_protected(&self) -> bool {
+        self.modifiers.contains(&FieldModifier::Protected)
+    }
+}
+
+// -----------------------------------------------------------------------------
+//  - Class-specific stuff -
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Clone)]
+#[repr(u16)]
+pub enum ClassModifier {
+    Public = 0x0001,
+    Private = 0x0002,
+    Protected = 0x0004,
+
+    Static = 0x0008,
+    Final = 0x0010,
+
+    Super = 0x0020,
+    Interface = 0x0200,
+    Abstract = 0x0400,
+    Synthetic = 0x1000,
+    Annotation = 0x2000,
+    Enum = 0x4000,
+
+    Module = 0x8000,
+}
+
+impl ClassModifier {
+    /// Returns the bytecode representation of the class modifier.
+    pub fn bytecode(&self) -> u16 {
+        // as stated in the docs, this should return the discriminant value of
+        // the enum, which is the bytecode representation of the class modifier
+        // (e.g. `ClassModifier::Public` should return `0x0001`).
+        // see: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
+        // TODO: check if there is a better (safe) way to do this...
+        unsafe { *(self as *const Self as *const u16) }
+    }
+}
+
+#[derive(Debug)]
+pub struct Class {
+    /// The name of the package the class belongs to.
+    pub package: Option<String>,
+    /// The name of the class.
+    pub name: String,
+    /// The name of the superclass of the class.
+    pub superclass: Option<String>,
+    /// A list of all modifiers of the class.
+    pub modifiers: Vec<ClassModifier>,
+    /// A list of all annotations of the class.
+    pub annotations: Vec<Annotation>,
+    /// A list of all methods of the class.
+    pub methods: Vec<Method>,
+    /// A list of all fields of the class.
+    pub fields: Vec<Field>,
+}
+
+impl Class {
+    /// Returns the simple name of the class.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Returns the fully qualified name of the class.
+    pub fn fullname(&self) -> String {
+        if let Some(package) = &self.package {
+            format!("{}.{}", package, self.name)
+        } else {
+            self.name.to_string()
+        }
+    }
+
+    /// Checks whether the class has the given `modifier`.
+    pub fn has_modifier(&self, modifier: ClassModifier) -> bool {
+        self.modifiers.contains(&modifier)
+    }
+
+    /// Tries to find an annotation by the given `name`. Returns `None` if no annotation with the
+    /// given `name` can be found.
+    pub fn get_annotation_by_name(&self, name: &str) -> Option<&Annotation> {
+        self.annotations.iter().find(|a| a.name == name)
+    }
+
+    /// Tries to find an annotation by the given `index`. Returns `None` if no annotation with the
+    /// given `index` can be found.
+    pub fn get_annotation_by_index(&self, index: usize) -> Option<&Annotation> {
+        self.annotations.get(index)
+    }
+
+    /// Checks whether the class has an annotation with the given `name`.
+    pub fn has_annotation_by_name(&self, name: &str) -> bool {
+        self.annotations.iter().any(|a| a.name == name)
+    }
+
+    /// Checks whether the class has an annotation with the given `index`.
+    pub fn has_annotation_by_index(&self, index: usize) -> bool {
+        self.annotations.get(index).is_some()
+    }
+
+    /// Tries to find a field by the given `name`. Returns `None` if no field with the given
+    /// `name` can be found.
+    pub fn get_field_by_name(&self, name: &str) -> Option<&Field> {
+        self.fields.iter().find(|f| f.name == name)
+    }
+
+    /// Tries to find a field by the given `index`. Returns `None` if no field with the given
+    /// `index` can be found.
+    pub fn get_field_by_index(&self, index: usize) -> Option<&Field> {
+        self.fields.get(index)
+    }
+
+    /// Tries to find a method by the given `name`. Returns `None` if no method with the given
+    /// `name` can be found.
+    pub fn get_method_by_name(&self, name: &str) -> Option<&Method> {
+        self.methods.iter().find(|m| m.name == name)
+    }
+
+    /// Tries to find a method by the given `index`. Returns `None` if no method with the given
+    /// `index` can be found.
+    pub fn get_method_by_index(&self, index: usize) -> Option<&Method> {
+        self.methods.get(index)
+    }
+}


### PR DESCRIPTION
### Added
- `Container` struct for attribute factories
- Registration of attribute factories in `Container`
- `AnyAttribute` trait for dynamic attribute handling
- Factory implementations for various attribute types
- `element_value_string` function for `ElementValue` conversion

### Changed
- `read_attribute` now accepts a `Container` reference
- `read_classfile`, `read_field`, and `read_method` now accept a `Container` reference
- `ClassFile`, `Field`, and `Method` now store attributes in a `HashMap`
- Updated examples to use new attribute handling system

### Removed
- Enum `Attribute` and its variants
- Direct usage of `Attribute` enum in favor of dynamic handling